### PR TITLE
Remove truffle artifacts from code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ cache:
 matrix:
   fast_finish: true
 script:
+  - npx truffle compile
   - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,14 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -3503,6 +3511,27 @@
       "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.2.tgz",
       "integrity": "sha1-AbGJt4UFVmrhaJwjnHyi3RIc/kw="
     },
+    "truffle-expect": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.3.tgz",
+      "integrity": "sha1-m3XO80O9WW5+XbyHj18bLjGKlEw="
+    },
+    "truffle-provisioner": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/truffle-provisioner/-/truffle-provisioner-0.1.0.tgz",
+      "integrity": "sha1-Ap5SScEBUwBzhTXgT97ZMaU8T2I="
+    },
+    "truffle-resolver": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/truffle-resolver/-/truffle-resolver-4.0.3.tgz",
+      "integrity": "sha512-CXzfXcG6LxQm5cWXH/HJE85pnvHvPDB16l2pzk9/q1F9Y4BWD2xS4rYzvrXGjkPNGrYTkNY+baF5YN/6eIGGgQ==",
+      "requires": {
+        "async": "2.6.0",
+        "truffle-contract": "3.0.5",
+        "truffle-expect": "0.0.3",
+        "truffle-provisioner": "0.1.0"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -3656,7 +3685,7 @@
       }
     },
     "zos-lib": {
-      "version": "git://github.com/zeppelinos/zos-lib.git#d37754c1a2f900ec8d3caaefc8d343c448eeb597",
+      "version": "git://github.com/zeppelinos/zos-lib.git#f6901d5bc9679f8ebdbf5da858deb698f5e0a13b",
       "requires": {
         "zeppelin-solidity": "1.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "shelljs": "^0.8.1",
     "truffle": "^4.1.6",
     "truffle-contract": "^3.0.5",
+    "truffle-provisioner": "^0.1.0",
+    "truffle-resolver": "^4.0.3",
     "zos-lib": "git://github.com/zeppelinos/zos-lib.git"
   },
   "devDependencies": {

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -1,11 +1,10 @@
-global.artifacts = artifacts
+// Set global variables to be used in scripts and models
 global.web3 = web3
-global.truffleDefaults = artifacts.require('ContractDirectory').class_defaults // TODO: Make less horrible
+global.artifacts = artifacts
 
 const program = require('commander')
 
 module.exports = function(cb) {
-
   program
     .option('--network [network]', 'Truffle network')
     .option('--from [from]', 'Sender')

--- a/src/models/AppManager.js
+++ b/src/models/AppManager.js
@@ -2,11 +2,12 @@ import decodeLogs from '../utils/decodeLogs';
 import encodeCall from '../utils/encodeCall';
 import Stdlib from './Stdlib';
 import _ from 'lodash';
+import makeContract from '../utils/contract';
 
-const AppManager = artifacts.require('PackagedAppManager');
-const AppDirectory = artifacts.require('AppDirectory');
-const Package = artifacts.require('Package');
-const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory');
+const AppManager = makeContract('PackagedAppManager');
+const AppDirectory = makeContract('AppDirectory');
+const Package = makeContract('Package');
+const UpgradeabilityProxyFactory = makeContract('UpgradeabilityProxyFactory');
 
 class AppManagerWrapper {
 

--- a/src/models/Kernel.js
+++ b/src/models/Kernel.js
@@ -1,13 +1,8 @@
-const contract = require("truffle-contract")
-const Kernel = contract(require('../../node_modules/kernel/build/contracts/Kernel.json'))
-const Release = contract(require('../../node_modules/kernel/build/contracts/Release.json'))
-const ZepToken = contract(require('../../node_modules/kernel/build/contracts/ZepToken.json'))
-const Vouching = contract(require('../../node_modules/kernel/build/contracts/Vouching.json'))
-
-Kernel.setProvider(web3.currentProvider)
-Release.setProvider(web3.currentProvider)
-ZepToken.setProvider(web3.currentProvider)
-Vouching.setProvider(web3.currentProvider)
+const makeContract = require('../utils/contract')
+const Kernel = makeContract(require('../../node_modules/kernel/build/contracts/Kernel.json'))
+const Release = makeContract(require('../../node_modules/kernel/build/contracts/Release.json'))
+const ZepToken = makeContract(require('../../node_modules/kernel/build/contracts/ZepToken.json'))
+const Vouching = makeContract(require('../../node_modules/kernel/build/contracts/Vouching.json'))
 
 export default class KernelWrapper {
   constructor(address, txParams) {

--- a/src/models/Stdlib.js
+++ b/src/models/Stdlib.js
@@ -2,8 +2,9 @@ import truffleContract from 'truffle-contract';
 import fs from 'fs';
 import path from 'path';
 import npm from 'npm-programmatic';
+import makeContract from '../utils/contract'
 
-const ContractDirectory = artifacts.require('ContractDirectory');
+const ContractDirectory = makeContract('ContractDirectory');
 
 export default class Stdlib {
   constructor(nameWithVersion, owner) {
@@ -30,9 +31,7 @@ export default class Stdlib {
     const implName = this.getPackage().contracts[contractName];
     if (!implName) throw `Contract ${contractName} not found in package`;
     const schema = JSON.parse(fs.readFileSync(`node_modules/${this.name}/build/contracts/${implName}.json`));
-    const contract = truffleContract(schema);
-    contract.setProvider(web3.currentProvider);
-    contract.defaults(ContractDirectory.class_defaults);
+    const contract = makeContract(schema);
     return contract;
   }
 

--- a/src/scripts/create-proxy.js
+++ b/src/scripts/create-proxy.js
@@ -1,9 +1,9 @@
 import AppManager from '../models/AppManager'
 import PackageFilesInterface from '../utils/PackageFilesInterface'
 import Logger from '../utils/Logger'
+import makeContract from '../utils/contract'
 
 const log = new Logger('creaty-proxy')
-
 
 async function createProxy(contractAlias, { network, from, packageFileName }) {
   if (contractAlias === undefined) {
@@ -27,7 +27,7 @@ async function createProxy(contractAlias, { network, from, packageFileName }) {
     return
   }
 
-  const contractClass = artifacts.require(contractName)
+  const contractClass = makeContract(contractName)
   const proxyInstance = await appManager.createProxy(contractClass, contractAlias)
 
   const { address } = proxyInstance

--- a/src/scripts/register.js
+++ b/src/scripts/register.js
@@ -4,7 +4,7 @@ import kernelAddress from '../utils/kernelAddress'
 async function register(releaseAddress, { network, from }) {
   if(!releaseAddress) throw new Error('You must provide a release address')
   const address = kernelAddress(network)
-  const txParams = Object.assign({}, global.truffleDefaults, { from })
+  const txParams = { from }
 
   const kernel = new Kernel(address, txParams)
   await kernel.validateCanRegister(releaseAddress)

--- a/src/scripts/sync.js
+++ b/src/scripts/sync.js
@@ -2,6 +2,7 @@ import AppManager from '../models/AppManager'
 import PackageFilesInterface from '../utils/PackageFilesInterface'
 import Logger from '../utils/Logger'
 import Stdlib from '../models/Stdlib';
+import makeContract from '../utils/contract'
 
 const log = new Logger('sync')
 
@@ -43,7 +44,7 @@ async function sync({ network, from, packageFileName }) {
 
   for (let contractName in zosPackage.contracts) {
     // TODO: store the implementation's hash to avoid unnecessary deployments
-    const contractClass = artifacts.require(zosPackage.contracts[contractName])
+    const contractClass = makeContract(zosPackage.contracts[contractName])
     const contractInstance = await appManager.setImplementation(contractClass, contractName)
       zosNetworkFile.package.contracts[contractName] = contractInstance.address
   }

--- a/src/scripts/unvouch.js
+++ b/src/scripts/unvouch.js
@@ -5,7 +5,7 @@ async function unvouch(releaseAddress, rawAmount, { network, from }) {
   if(!releaseAddress) throw new Error('You must provide a release address to unvouch from')
   if(!rawAmount) throw new Error('You must provide an amount of ZEP tokens to unvouch')
   const address = kernelAddress(network)
-  const txParams = Object.assign({}, global.truffleDefaults, { from })
+  const txParams = { from }
 
   const data = ''
   const amount = new web3.BigNumber(rawAmount)

--- a/src/scripts/vouch.js
+++ b/src/scripts/vouch.js
@@ -5,7 +5,7 @@ async function vouch(releaseAddress, rawAmount, { network, from }) {
   if(!releaseAddress) throw new Error('You must provide a release address to vouch for')
   if(!rawAmount) throw new Error('You must provide a vouching amount of ZEP tokens')
   const address = kernelAddress(network)
-  const txParams = Object.assign({}, global.truffleDefaults, { from })
+  const txParams = { from }
 
   const data = ''
   const amount = new web3.BigNumber(rawAmount)

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -1,0 +1,28 @@
+const truffleContract = require("truffle-contract")
+const truffleProvision = require("truffle-provisioner")
+
+function getDefaults() {
+  if (typeof(artifacts) !== 'undefined') {
+    return artifacts.options
+  } else {
+    throw new "Could not retrieve truffle defaults"
+  }
+}
+
+module.exports = function(contractOrName) {
+  // TODO: Consider sourcing from node_modules so we don't need to import and compile these contracts in this project
+  const data = typeof(contractOrName) === 'string'
+    ? require(`../../build/contracts/${contractOrName}.json`)
+    : contractOrName;
+  const contract = truffleContract(data)
+
+  // Truffle injects entirely different objects in testing and in exec, hence this if
+  if (process.env.NODE_ENV === 'test') {
+    contract.setProvider(web3.currentProvider)
+    contract.defaults({gas: 6721975, gasPrice: 100000000000, from: web3.eth.accounts[0] })
+  } else {
+    truffleProvision(contract, getDefaults())
+  }
+  
+  return contract
+}

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -51,7 +51,7 @@ contract('create-proxy command', function([_, owner]) {
 
   it('should be able to handle proxies for more than one contract', async function() {
     const customAlias = 'SomeOtherAlias';
-    await addImplementation('ImplV2.sol', customAlias, {packageFileName});
+    await addImplementation('ImplV2', customAlias, {packageFileName});
     await sync({ packageFileName, network, from });
     await createProxy(contractAlias, {packageFileName, network, from});
     await createProxy(customAlias, {packageFileName, network, from});


### PR DESCRIPTION
Artifacts require failed to fetch the contract when called
as a node module in another repo, as the working directory
was set to the parent's.

This change loads each contract manually from the build/
contracts directory, and provisions it with defaults.