### PR TITLE
Split kernel model into a wrapper and a provider

### DIFF
--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -1,6 +1,6 @@
 import Logger from '../utils/Logger'
-import Kernel from '../models/Kernel'
 import Distribution from '../models/Distribution'
+import KernelProvider from "../zos-lib/kernel/KernelProvider"
 import ContractsProvider from '../models/ContractsProvider'
 import PackageFilesInterface from '../utils/PackageFilesInterface'
 
@@ -48,7 +48,7 @@ async function deploy(version, { network, from, packageFileName }) {
   // 5. Register release into kernel
   const kernelAddress = zosPackage.kernel.address
   log.info(`Registering release into kernel address ${kernelAddress}`)
-  const kernel = new Kernel(kernelAddress)
+  const kernel = await KernelProvider.from(from, kernelAddress)
   await kernel.register(release.address)
 
   zosNetworkFile.provider = { address: release.address }

--- a/src/scripts/register.js
+++ b/src/scripts/register.js
@@ -1,11 +1,10 @@
-import Kernel from '../models/Kernel'
 import kernelAddress from '../utils/kernelAddress'
+import KernelProvider from "../zos-lib/kernel/KernelProvider";
 
 async function register(releaseAddress, { network, from }) {
   if(!releaseAddress) throw 'You must provide a release address'
   const address = kernelAddress(network)
-  const txParams = { from }
-  const kernel = new Kernel(address, txParams)
+  const kernel = await KernelProvider.from(from, address)
   await kernel.validateCanRegister(releaseAddress)
 
   try {

--- a/src/scripts/unvouch.js
+++ b/src/scripts/unvouch.js
@@ -1,15 +1,14 @@
-import Kernel from '../models/Kernel'
 import kernelAddress from '../utils/kernelAddress'
+import KernelProvider from "../zos-lib/kernel/KernelProvider";
 
 async function unvouch(releaseAddress, rawAmount, { network, from }) {
   if(!releaseAddress) throw 'You must provide a release address to unvouch from'
   if(!rawAmount) throw 'You must provide an amount of ZEP tokens to unvouch'
   const address = kernelAddress(network)
-  const txParams = { from }
 
   const data = ''
   const amount = new web3.BigNumber(rawAmount)
-  const kernel = new Kernel(address, txParams)
+  const kernel = await KernelProvider.from(from, address)
   await kernel.validateCanUnvouch(releaseAddress, amount)
 
   try {

--- a/src/scripts/vouch.js
+++ b/src/scripts/vouch.js
@@ -1,15 +1,14 @@
-import Kernel from '../models/Kernel'
 import kernelAddress from '../utils/kernelAddress'
+import KernelProvider from "../zos-lib/kernel/KernelProvider";
 
 async function vouch(releaseAddress, rawAmount, { network, from }) {
   if(!releaseAddress) throw 'You must provide a release address to vouch for'
   if(!rawAmount) throw 'You must provide a vouching amount of ZEP tokens'
   const address = kernelAddress(network)
-  const txParams = { from }
 
   const data = ''
   const amount = new web3.BigNumber(rawAmount)
-  const kernel = new Kernel(address, txParams)
+  const kernel = await KernelProvider.from(from, address)
   await kernel.validateCanVouch(releaseAddress, amount)
 
   try {

--- a/src/zos-lib/kernel/KernelProvider.js
+++ b/src/zos-lib/kernel/KernelProvider.js
@@ -1,0 +1,28 @@
+import KernelWrapper from "./KernelWrapper";
+import ContractsProvider from '../../models/ContractsProvider'
+
+export default {
+  async from(owner, address) {
+    this._fetchKernel(address)
+    await this._fetchZepToken()
+    await this._fetchVouching()
+    return new KernelWrapper(owner, this.kernel, this.zepToken, this.vouching)
+  },
+
+  _fetchKernel(address) {
+    const Kernel = ContractsProvider.kernel()
+    this.kernel = new Kernel(address)
+  },
+
+  async _fetchZepToken() {
+    const ZepToken = ContractsProvider.zepToken()
+    const zepTokenAddress = await this.kernel.token()
+    this.zepToken = new ZepToken(zepTokenAddress)
+  },
+
+  async _fetchVouching() {
+    const Vouching = ContractsProvider.vouching()
+    const vouchingAddress = await this.kernel.vouches()
+    this.vouching = new Vouching(vouchingAddress)
+  }
+}


### PR DESCRIPTION
**MERGE AFTER #61** (change base branch to the [refactor branch](https://github.com/zeppelinos/zos-cli/tree/refactor_branch) before merging)

Following what I described in #60, this PR splits the kernel model into a wrapper and a provider.
Note there is no need of a deployer here, however we have that code spread somehow within the kernel project.