### PR TITLE
Default alias to name in add-implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ npx truffle compile
 The next step is to register all the contract implementations of the first `version` of your project. To do this please run:
 
 ```
-zos add-implementation [CONTRACT_NAME_1] [ALIAS_2] --network [NETWORK]
-zos add-implementation [CONTRACT_NAME_2] [ALIAS_2] --network [NETWORK]
+zos add-implementation [CONTRACT_NAME_1] --network [NETWORK]
+zos add-implementation [CONTRACT_NAME_2] --network [NETWORK]
 ...
-zos add-implementation [CONTRACT_NAME_N] [ALIAS_N] --network [NETWORK]
+zos add-implementation [CONTRACT_NAME_N] --network [NETWORK]
 ```
 
 Where `[CONTRACT_NAME]` is the name of your Solidity contract, and `[ALIAS]` is the name under which it will be registered 
@@ -94,7 +94,7 @@ in zeppelin_os.
 
 In our example, run:
 ```
-zos add-implementation MyContract MyContract --network development
+zos add-implementation MyContract --network development
 ```
 
 To have your `package.zos.json` file always up-to-date, run `zos add-implementation` for every new contract you add to your project.
@@ -258,7 +258,7 @@ Initializing the distribution will create a `package.zos.json` file that will tr
 ```
 zos add-implementation <contract-name> <alias> --network=<network>,
 ```
-where `<contract-name>` is the name of the contract and `<alias>` is an alternative reference to it. Note that this command must be repeated once for each contract included in the distribution. This will update the `package.zos.json` file with the contract names. 
+where `<contract-name>` is the name of the contract and the optional `<alias>` is an alternative reference to it. Note that this command must be repeated once for each contract included in the distribution. This will update the `package.zos.json` file with the contract names. 
 
 Finally, we need to deploy the `Package` representing the distribution, the `Release` containing the stdlib, and the individual library contracts, which must then be registered in the kernel. All of this is accomplished by:
 ```

--- a/src/models/AppController.js
+++ b/src/models/AppController.js
@@ -56,6 +56,7 @@ export default class AppController {
   }
 
   addImplementation(contractAlias, contractName) {
+    // TODO: Add some extra metadata on the contract when adding it, and validate it exists
     this.package.contracts[contractAlias] = contractName;
   }
 

--- a/src/scripts/add-implementation.js
+++ b/src/scripts/add-implementation.js
@@ -2,7 +2,7 @@ import AppController from "../models/AppController";
 
 export default function addImplementation({ contractName, contractAlias, packageFileName = null }) {
   if (contractName === undefined) throw new Error('Must provide a contract name')
-  if (contractAlias === undefined) throw new Error('Must provide an alias')
+  if (!contractAlias) contractAlias = contractName
 
   const appController = new AppController(packageFileName)
   appController.addImplementation(contractAlias, contractName)

--- a/test/scripts/add-implementation.test.js
+++ b/test/scripts/add-implementation.test.js
@@ -10,7 +10,7 @@ const should = require('chai')
 contract('add-implementation command', function() {
   const packageFileName = "test/tmp/package.zos.json";
   const appName = "MyApp";
-  const contractName = "MyContract_v0.sol";
+  const contractName = "MyContract_v0";
   const contractAlias = "MyContract";
   const defaultVersion = "0.1.0";
   
@@ -29,7 +29,7 @@ contract('add-implementation command', function() {
 
   it('should allow to change an existing implementation', function() {
     addImplementation({ contractName, contractAlias, packageFileName });
-    const customFileName = "MyContract_v1.sol";
+    const customFileName = "MyContract_v1";
     addImplementation({ contractName: customFileName, contractAlias, packageFileName });
     const data = fs.parseJson(packageFileName);
     data.contracts[contractAlias].should.eq(customFileName);
@@ -37,9 +37,9 @@ contract('add-implementation command', function() {
 
   it('should handle multiple contracts', function() {
     const customAlias1 = "MyContract";
-    const customFileName1 = "MyContract_v2.sol";
+    const customFileName1 = "MyContract_v2";
     const customAlias2 = "MyOtherContract";
-    const customFileName2 = "MyOtherContract_v0.sol";
+    const customFileName2 = "MyOtherContract_v0";
     addImplementation({ contractName: customFileName1, contractAlias: customAlias1, packageFileName });
     addImplementation({ contractName: customFileName2, contractAlias: customAlias2, packageFileName });
     const data = fs.parseJson(packageFileName);
@@ -47,13 +47,10 @@ contract('add-implementation command', function() {
     data.contracts[customAlias2].should.eq(customFileName2);
   });
 
-  // TODO: implement
-  it.skip('should use a default alias if one is not provided', function() {
-    addImplementation({ contractName, contractAlias: null, packageFileName });
+  it('should use a default alias if one is not provided', function() {
+    addImplementation({ contractName, contractAlias: undefined, packageFileName });
     const data = fs.parseJson(packageFileName);
-    const expectedAlias = contractName.split('.')[0];
-    console.log(data);
-    data.contracts[expectedAlias].should.eq(contractName);
+    data.contracts[contractName].should.eq(contractName);
   });
 
   // TODO: test for invalid alias names


### PR DESCRIPTION
Add-implementation no longer requires an alias option. If not set, it will default to the contract name.