### PR TITLE
Upgrade multiple proxies with a single command

### DIFF
--- a/contracts/Imports.sol
+++ b/contracts/Imports.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.21;
 
 import "zos-kernel/contracts/Release.sol";
+import "zos-lib/contracts/upgradeability/Proxy.sol";
 import "zos-lib/contracts/application/versioning/Package.sol";
 import "zos-lib/contracts/application/versioning/ContractDirectory.sol";
 import "zos-lib/contracts/application/management/AppDirectory.sol";

--- a/contracts/mocks/ImplV1.sol
+++ b/contracts/mocks/ImplV1.sol
@@ -12,3 +12,9 @@ contract ImplV1 {
     return "V1";
   }
 }
+
+contract AnotherImplV1 is ImplV1 {
+  function say() public pure returns (string) {
+    return "AnotherV1";
+  }
+}

--- a/contracts/mocks/ImplV2.sol
+++ b/contracts/mocks/ImplV2.sol
@@ -12,3 +12,9 @@ contract ImplV2 is ImplV1 {
     return "V2";
   }
 }
+
+contract AnotherImplV2 is ImplV2 {
+  function say() public pure returns (string) {
+    return "AnotherV2";
+  }
+}

--- a/src/commands/users/upgrade-proxy.js
+++ b/src/commands/users/upgrade-proxy.js
@@ -3,12 +3,13 @@ import runWithTruffle from '../../utils/runWithTruffle'
 
 module.exports = function(program) {
   program
-    .command('upgrade-proxy <alias> <address>')
-    .usage('<alias> <address> --network <network> [options]')
+    .command('upgrade-proxy [alias] [address]')
+    .usage('[alias] [address] --network <network> [options]')
     .description(`Upgrade a proxied contract to a new implementation.
-      Provide the <alias> name you used to register your contract.`)
+      Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
     .option('-i, --init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
     .option('-a, --args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
+    .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')
     .action(function (contractAlias, proxyAddress, options) {
@@ -19,7 +20,7 @@ module.exports = function(program) {
       if(typeof initArgs === 'string') initArgs = initArgs.split(",")
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
-      const { from, network } = options
-      runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, network, from, initMethod, initArgs }), network)
+      const { from, network, all } = options
+      runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, network, from, initMethod, initArgs, all }), network)
     })
 }

--- a/src/models/AppController.js
+++ b/src/models/AppController.js
@@ -67,7 +67,7 @@ export default class AppController {
     return this._package;
   }
 
-  async getContractClass(contractAlias) {
+  getContractClass(contractAlias) {
     const contractName = this.package.contracts[contractAlias];
     if (contractName) {
       return ContractsProvider.getFromArtifacts(contractName);

--- a/src/scripts/upgrade-proxy.js
+++ b/src/scripts/upgrade-proxy.js
@@ -1,7 +1,10 @@
 import AppController from "../models/AppController";
 
-export default async function upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, network, txParams = {}, packageFileName = undefined, networkFileName = undefined }) {
+export default async function upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, network, all, txParams = {}, packageFileName = undefined, networkFileName = undefined }) {
+  if (!contractAlias && !all) {
+    throw new Error("Please choose a contract name to upgrade, or set --all to upgrade all proxies in the application")
+  }
   const appController = new AppController(packageFileName).onNetwork(network, txParams, networkFileName);
-  await appController.upgradeProxy(contractAlias, proxyAddress, initMethod, initArgs);
+  await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
   appController.writeNetworkPackage();
 }

--- a/test/scripts/upgrade-proxy.test.js
+++ b/test/scripts/upgrade-proxy.test.js
@@ -7,8 +7,13 @@ import upgradeProxy from "../../src/scripts/upgrade-proxy.js";
 import { FileSystem as fs } from "zos-lib";
 import { cleanup, cleanupfn } from "../helpers/cleanup.js";
 
+const Proxy = artifacts.require('Proxy');
+const ImplV1 = artifacts.require('ImplV1');
+const ImplV2 = artifacts.require('ImplV2');
+
 const should = require('chai')
       .use(require('chai-as-promised'))
+      .use(require('../helpers/assertions'))
       .should();
 
 contract('upgrade-proxy command', function([_, owner]) {
@@ -16,10 +21,8 @@ contract('upgrade-proxy command', function([_, owner]) {
   const from = owner;
   const txParams = { from };
   const appName = "MyApp";
-  const contractName = "ImplV1";
-  const contractAlias = "Impl";
-  const defaultVersion = "0.1.0";
-  const version = "0.2.0";
+  const v1string = "0.1.0";
+  const v2string = "0.2.0";
   const network = "test";
   const packageFileName = "test/tmp/package.zos.json";
   const networkFileName = `test/tmp/package.zos.${network}.json`;
@@ -28,22 +31,117 @@ contract('upgrade-proxy command', function([_, owner]) {
     cleanup(packageFileName)
     cleanup(networkFileName)
 
-    await init({ name: appName, version: defaultVersion, packageFileName });
-    await addImplementation({ contractName, contractAlias, packageFileName });
+    await init({ name: appName, version: v1string, packageFileName });
+    await addImplementation({ contractName: "ImplV1", contractAlias: "Impl", packageFileName });
+    await addImplementation({ contractName: "AnotherImplV1", contractAlias: "AnotherImpl", packageFileName });
     await sync({ packageFileName, network, txParams });
-    await createProxy({ contractAlias, packageFileName, network, txParams });
-    await newVersion({ version, packageFileName, txParams });
-    await addImplementation({ contractName, contractAlias, packageFileName });
+    
+    const networkDataV1 = fs.parseJson(networkFileName);
+    this.implV1Address = networkDataV1.contracts["Impl"];
+    this.anotherImplV1Address = networkDataV1.contracts["AnotherImpl"];
+
+    await createProxy({ contractAlias: "Impl", packageFileName, network, txParams });
+    await createProxy({ contractAlias: "Impl", packageFileName, network, txParams });
+    await createProxy({ contractAlias: "AnotherImpl", packageFileName, network, txParams });
+  
+    await newVersion({ version: v2string, packageFileName, txParams });
+    await addImplementation({ contractName: "ImplV2", contractAlias: "Impl", packageFileName });
+    await addImplementation({ contractName: "AnotherImplV2", contractAlias: "AnotherImpl", packageFileName });
     await sync({ packageFileName, network, txParams });
+
+    const networkDataV2 = fs.parseJson(networkFileName);
+    this.implV2Address = networkDataV2.contracts["Impl"];
+    this.anotherImplV2Address = networkDataV2.contracts["AnotherImpl"];
   });
 
   after(cleanupfn(packageFileName));
   after(cleanupfn(networkFileName));
 
-  it('should upgrade the version of a proxy', async function() {
-    await upgradeProxy({ contractAlias, proxyAddress: null, network, packageFileName, txParams });
+  const assertProxyInfo = async function(contractAlias, proxyIndex, { version, implementation, address, value }) {
     const data = fs.parseJson(networkFileName);
-    const proxy = data.proxies[contractAlias][0];
-    proxy.version.should.eq(version);
+    const proxyInfo = data.proxies[contractAlias][proxyIndex];
+    
+    if (address)  {
+      proxyInfo.address.should.eq(address);
+    } else {
+      proxyInfo.address.should.be.nonzeroAddress;
+    }
+
+    if (implementation) {
+      // NOTE: The following may fail if transparent proxies are implemented
+      const proxy = Proxy.at(proxyInfo.address);
+      const actualImplementation = await proxy.implementation();
+      actualImplementation.should.eq(implementation);
+    }
+
+    if (version)  {
+      proxyInfo.version.should.eq(version);
+    }
+    
+    if (value) {
+      const proxy = ImplV1.at(proxyInfo.address);
+      const actualValue = await proxy.value();
+      actualValue.toNumber().should.eq(value);
+    }
+
+    return proxyInfo;
+  }
+
+  it('should upgrade the version of a proxy given its address', async function() {
+    // Upgrade single proxy
+    const proxyAddress = fs.parseJson(networkFileName).proxies["Impl"][0].address;
+    await upgradeProxy({ contractAlias: "Impl", proxyAddress, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address, address: proxyAddress });
+
+    // Check other proxies were unmodified
+    await assertProxyInfo('Impl', 1, { version: v1string, implementation: this.implV1Address });
+    await assertProxyInfo('AnotherImpl', 0, { version: v1string, implementation: this.anotherImplV1Address });
+  });
+
+  it('should upgrade the version of all proxies given the contract alias', async function() {
+    // Upgrade all "Impl" proxies
+    await upgradeProxy({ contractAlias: "Impl", proxyAddress: undefined, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address });
+    await assertProxyInfo('Impl', 1, { version: v2string, implementation: this.implV2Address });
+
+    // Keep AnotherImpl unmodified
+    await assertProxyInfo('AnotherImpl', 0, { version: v1string, implementation: this.anotherImplV1Address });
+  });
+
+  it('should upgrade the version of all proxies in the app', async function() {
+    await upgradeProxy({ contractAlias: undefined, proxyAddress: undefined, all: true, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address });
+    await assertProxyInfo('Impl', 1, { version: v2string, implementation: this.implV2Address });
+    await assertProxyInfo('AnotherImpl', 0, { version: v2string, implementation: this.anotherImplV2Address });
+  });
+
+  it('should require all flag to upgrade all proxies', async function() {
+    await upgradeProxy(
+      { contractAlias: undefined, proxyAddress: undefined, all: false, network, packageFileName, txParams }
+    ).should.be.rejected;
+  });
+
+  it('should upgrade the remaining proxies if one was already upgraded', async function() {
+    // Upgrade a single proxy
+    const proxyAddress = fs.parseJson(networkFileName).proxies["Impl"][0].address;
+    await upgradeProxy({ contractAlias: "Impl", proxyAddress, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address, address: proxyAddress });
+
+    // Upgrade all
+    await upgradeProxy({ contractAlias: undefined, proxyAddress: undefined, all: true, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 1, { version: v2string, implementation: this.implV2Address });
+    await assertProxyInfo('AnotherImpl', 0, { version: v2string, implementation: this.anotherImplV2Address });
+  });
+
+  it('should upgrade a single proxy and migrate it', async function() {
+    const proxyAddress = fs.parseJson(networkFileName).proxies["Impl"][0].address;
+    await upgradeProxy({ contractAlias: "Impl", initMethod: "migrate", initArgs: [42], proxyAddress, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address, address: proxyAddress, value: 42 });
+  });
+
+  it('should upgrade multiple proxies and migrate them', async function() {
+    await upgradeProxy({ contractAlias: "Impl", initMethod: "migrate", initArgs: [42], proxyAddress: undefined, network, packageFileName, txParams });
+    await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address, value: 42 });
+    await assertProxyInfo('Impl', 1, { version: v2string, implementation: this.implV2Address, value: 42 });
   });
 });


### PR DESCRIPTION
Command upgrade-proxy will now upgrade all proxies for a given
contract alias if no address is specified. Also, if no contract
alias is set, and a --all flag is set, all contracts in the app
will be upgraded to the new version.

Fixes #33 