### PR TITLE
Check modifications in contracts before add/upgrade proxy

### DIFF
--- a/src/commands/users/create-proxy.js
+++ b/src/commands/users/create-proxy.js
@@ -11,6 +11,7 @@ module.exports = function(program) {
     .option('-a, --args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')
+    .option('--force', 'Force creation of the proxy even if contracts have local modifications')
     .action(function (contractAlias, options) {
       let initMethod = options.init
       if(typeof initMethod === 'boolean') initMethod = 'initialize'
@@ -19,7 +20,7 @@ module.exports = function(program) {
       if(typeof initArgs === 'string') initArgs = initArgs.split(",")
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
-      const { from, network } = options
-      runWithTruffle(async () => await createProxy({ contractAlias, network, from, initMethod, initArgs }), network)
+      const { from, network, force } = options
+      runWithTruffle(async () => await createProxy({ contractAlias, network, from, initMethod, initArgs, force }), network)
     })
 }

--- a/src/commands/users/upgrade-proxy.js
+++ b/src/commands/users/upgrade-proxy.js
@@ -12,6 +12,7 @@ module.exports = function(program) {
     .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')
+    .option('--force', 'Force upgrading the proxy even if contracts have local modifications')
     .action(function (contractAlias, proxyAddress, options) {
       let initMethod = options.init
       if(typeof initMethod === 'boolean') initMethod = 'initialize'
@@ -20,7 +21,7 @@ module.exports = function(program) {
       if(typeof initArgs === 'string') initArgs = initArgs.split(",")
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
-      const { from, network, all } = options
-      runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, network, from, initMethod, initArgs, all }), network)
+      const { from, network, all, force } = options
+      runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, network, from, initMethod, initArgs, all, force }), network)
     })
 }

--- a/src/models/NetworkAppController.js
+++ b/src/models/NetworkAppController.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { Logger } from 'zos-lib';
 import { FileSystem as fs, AppManagerProvider, AppManagerDeployer } from "zos-lib";
+import { bytecodeDigest } from '../utils/digest';
 import StdlibProvider from './stdlib/StdlibProvider';
 import StdlibDeployer from './stdlib/StdlibDeployer';
 import Stdlib from './stdlib/Stdlib';
@@ -177,7 +178,7 @@ export default class NetworkAppController {
       log.info(`Uploaded ${contractName} at ${contractInstance.address}`);
       this.networkPackage.contracts[contractAlias] = {
         address: contractInstance.address,
-        bytecode: contractClass.bytecode
+        bytecodeHash: bytecodeDigest(contractClass.bytecode)
       };
     }));
   }
@@ -244,8 +245,8 @@ export default class NetworkAppController {
     if (!this.isApplicationContract(contractAlias)) return false;
     if (!this.isContractDeployed(contractAlias)) return true;
     const contractClass = ContractsProvider.getFromArtifacts(contractName);
-    const currentBytecode = contractClass.bytecode;
-    const deployedBytecode = this.networkPackage.contracts[contractAlias].bytecode;
+    const currentBytecode = bytecodeDigest(contractClass.bytecode);
+    const deployedBytecode = this.networkPackage.contracts[contractAlias].bytecodeHash;
     return currentBytecode != deployedBytecode;
   }
 

--- a/src/models/stdlib/Stdlib.js
+++ b/src/models/stdlib/Stdlib.js
@@ -1,5 +1,6 @@
 import StdlibInstaller from './StdlibInstaller';
 import { FileSystem as fs } from 'zos-lib'
+import _ from 'lodash';
 
 export default class Stdlib {
   constructor(nameAndVersion) {
@@ -22,6 +23,11 @@ export default class Stdlib {
     this._packageJson = fs.parseJson(filename)
     return this._packageJson
   }
+
+  hasContract(alias) {
+    if (!this.getPackage().contracts) return false;
+    return !_.isEmpty(this.getPackage().contracts[alias]);
+  }
   
   async install() {
     await StdlibInstaller.call(this.nameAndVersion)
@@ -32,5 +38,10 @@ export default class Stdlib {
     this.name = name
     this.version = version
     this.nameAndVersion = nameAndVersion;
+  }
+
+  static equalNameAndVersion(stdlib1, stdlib2) {
+    return stdlib1.name === stdlib2.name
+      && (stdlib1.getVersion ? stdlib1.getVersion() : stdlib1.version) === (stdlib2.getVersion ? stdlib2.getVersion() : stdlib2.version);
   }
 }

--- a/src/scripts/create-proxy.js
+++ b/src/scripts/create-proxy.js
@@ -2,7 +2,7 @@ import AppController from '../models/AppController';
 
 export default async function createProxy({ contractAlias, initMethod, initArgs, network, txParams = {}, packageFileName = undefined, networkFileName = undefined, force = false }) {
   const appController = new AppController(packageFileName).onNetwork(network, txParams, networkFileName);
-  await appController.checkContractChanged(contractAlias, !force);
+  await appController.checkLocalContractDeployed(contractAlias, !force);
   await appController.createProxy(contractAlias, initMethod, initArgs);
   appController.writeNetworkPackage();
 }

--- a/src/scripts/create-proxy.js
+++ b/src/scripts/create-proxy.js
@@ -1,7 +1,8 @@
 import AppController from '../models/AppController';
 
-export default async function createProxy({ contractAlias, initMethod, initArgs, network, txParams = {}, packageFileName = undefined, networkFileName = undefined }) {
+export default async function createProxy({ contractAlias, initMethod, initArgs, network, txParams = {}, packageFileName = undefined, networkFileName = undefined, force = false }) {
   const appController = new AppController(packageFileName).onNetwork(network, txParams, networkFileName);
+  await appController.checkContractChanged(contractAlias, !force);
   await appController.createProxy(contractAlias, initMethod, initArgs);
   appController.writeNetworkPackage();
 }

--- a/src/scripts/upgrade-proxy.js
+++ b/src/scripts/upgrade-proxy.js
@@ -6,7 +6,7 @@ export default async function upgradeProxy({ contractAlias, proxyAddress, initMe
   }
 
   const appController = new AppController(packageFileName).onNetwork(network, txParams, networkFileName);
-  await appController.checkContractsChanged(!force);
+  await appController.checkLocalContractsDeployed(!force);
   await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
   appController.writeNetworkPackage();
 }

--- a/src/scripts/upgrade-proxy.js
+++ b/src/scripts/upgrade-proxy.js
@@ -1,10 +1,12 @@
 import AppController from "../models/AppController";
 
-export default async function upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, network, all, txParams = {}, packageFileName = undefined, networkFileName = undefined }) {
+export default async function upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, network, all, txParams = {}, packageFileName = undefined, networkFileName = undefined, force = false }) {
   if (!contractAlias && !all) {
     throw new Error("Please choose a contract name to upgrade, or set --all to upgrade all proxies in the application")
   }
+
   const appController = new AppController(packageFileName).onNetwork(network, txParams, networkFileName);
+  await appController.checkContractsChanged(!force);
   await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
   appController.writeNetworkPackage();
 }

--- a/src/utils/digest.js
+++ b/src/utils/digest.js
@@ -1,0 +1,5 @@
+import crypto from 'crypto';
+
+export function bytecodeDigest(bytecode) {
+  return crypto.createHash('sha256').update(Buffer.from(bytecode, 'hex')).digest('hex');
+}

--- a/test/mocks/mock-stdlib-2/package.zos.test.json
+++ b/test/mocks/mock-stdlib-2/package.zos.test.json
@@ -8,7 +8,10 @@
   },
   "package": {
     "contracts": {
-      "Greeter": "0x102030"
+      "Greeter": {
+        "address": "0x102030",
+        "bytecode": "0x0002"
+      }
     }
   }
 }

--- a/test/mocks/mock-stdlib-2/package.zos.test.json
+++ b/test/mocks/mock-stdlib-2/package.zos.test.json
@@ -10,7 +10,7 @@
     "contracts": {
       "Greeter": {
         "address": "0x102030",
-        "bytecode": "0x0002"
+        "bytecodeHash": "0x0002"
       }
     }
   }

--- a/test/mocks/mock-stdlib/package.zos.test.json
+++ b/test/mocks/mock-stdlib/package.zos.test.json
@@ -8,7 +8,10 @@
   },
   "package": {
     "contracts": {
-      "Greeter": "0x1020"
+      "Greeter": {
+        "address": "0x1020",
+        "bytecode": "0x0001"
+      }
     }
   }
 }

--- a/test/mocks/mock-stdlib/package.zos.test.json
+++ b/test/mocks/mock-stdlib/package.zos.test.json
@@ -10,7 +10,7 @@
     "contracts": {
       "Greeter": {
         "address": "0x1020",
-        "bytecode": "0x0001"
+        "bytecodeHash": "0x0001"
       }
     }
   }

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -96,7 +96,7 @@ contract('create-proxy command', function([_, owner]) {
   describe('with local modifications', function () {
     beforeEach("changing local network file to have a different bytecode", async function () {
       const data = fs.parseJson(networkFileName);
-      data.contracts[contractAlias].bytecode = "0xabcd";
+      data.contracts[contractAlias].bytecodeHash = "0xabcd";
       fs.writeJson(networkFileName, data);
     });
 

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -4,6 +4,9 @@ import { cleanup, cleanupfn } from "../helpers/cleanup.js";
 import { FileSystem as fs } from "zos-lib";
 import createProxy from "../../src/scripts/create-proxy.js";
 import addImplementation from "../../src/scripts/add-implementation.js";
+import setStdlib from "../../src/scripts/set-stdlib.js";
+
+const ImplV1 = artifacts.require('ImplV1');
 
 const should = require('chai')
       .use(require('chai-as-promised'))
@@ -16,6 +19,8 @@ contract('create-proxy command', function([_, owner]) {
   const appName = "MyApp";
   const contractName = "ImplV1";
   const contractAlias = "Impl";
+  const anotherContractName = "AnotherImplV1";
+  const anotherContractAlias = "AnotherImpl";
   const defaultVersion = "0.1.0";
   const network = "test";
   const packageFileName = "test/tmp/package.zos.json";
@@ -26,18 +31,28 @@ contract('create-proxy command', function([_, owner]) {
     cleanup(networkFileName)
     await init({ name: appName, version: defaultVersion, packageFileName });
     await addImplementation({ contractName, contractAlias, packageFileName });
+    await addImplementation({ contractName: anotherContractName, contractAlias: anotherContractAlias, packageFileName });
     await sync({ packageFileName, network, txParams });
   });
 
   after(cleanupfn(packageFileName))
   after(cleanupfn(networkFileName))
 
+  const assertProxy = async function(proxyInfo, { version, say }) {
+    proxyInfo.address.should.be.nonzeroAddress;
+    proxyInfo.version.should.eq(version);
+
+    if (say) {
+      const proxy = await ImplV1.at(proxyInfo.address);
+      const said = await proxy.say();
+      said.should.eq(say);
+    }
+  }
+
   it('should create a proxy for one of its contracts', async function() {
     await createProxy({ contractAlias, packageFileName, network, txParams });
     const data = fs.parseJson(networkFileName);
-    const proxy0 = data.proxies[contractAlias][0];
-    proxy0.address.should.be.not.null;
-    proxy0.version.should.be.eq(defaultVersion);
+    await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
   });
 
   it('should be able to have multiple proxies for one of its contracts', async function() {
@@ -49,17 +64,48 @@ contract('create-proxy command', function([_, owner]) {
   });
 
   it('should be able to handle proxies for more than one contract', async function() {
-    const customAlias = 'SomeOtherAlias';
-    await addImplementation({ contractName: 'ImplV2', contractAlias: customAlias, packageFileName });
-    await sync({ packageFileName, network, txParams });
     await createProxy({ contractAlias, packageFileName, network, txParams });
-    await createProxy({ contractAlias: customAlias, packageFileName, network, txParams });
+    await createProxy({ contractAlias: anotherContractAlias, packageFileName, network, txParams });
     const data = fs.parseJson(networkFileName);
-    const proxy0 = data.proxies[contractAlias][0];
-    const proxy1 = data.proxies[customAlias][0];
-    proxy0.address.should.be.not.null;
-    proxy0.version.should.be.eq(defaultVersion);
-    proxy1.address.should.be.not.null;
-    proxy1.version.should.be.eq(defaultVersion);
+    await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
+    await assertProxy(data.proxies[anotherContractAlias][0], { version: defaultVersion, say: "AnotherV1" });
   });
+
+  describe('with stdlib', function () {
+    beforeEach('setting stdlib', async function () {
+      await setStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFileName });
+      await sync({ packageFileName, network, txParams, deployStdlib: true });
+    });
+
+    it('should create a proxy for a stdlib contract', async function () {
+      await createProxy({ contractAlias: 'Greeter', packageFileName, network, txParams });
+      const data = fs.parseJson(networkFileName);
+      await assertProxy(data.proxies['Greeter'][0], { version: defaultVersion });
+    });
+  });
+
+  describe('with local modifications', function () {
+    beforeEach("changing local network file to have a different bytecode", async function () {
+      const data = fs.parseJson(networkFileName);
+      data.contracts[contractAlias].bytecode = "0xabcd";
+      fs.writeJson(networkFileName, data);
+    });
+
+    it('should refuse to create a proxy for a modified contract', async function () {
+      await createProxy({ contractAlias, packageFileName, network, txParams }).should.be.rejected;
+    });
+
+    it('should create a proxy for an unmodified contract', async function () {
+      await createProxy({ contractAlias: anotherContractAlias, packageFileName, network, txParams });
+      const data = fs.parseJson(networkFileName);
+      await assertProxy(data.proxies[anotherContractAlias][0], { version: defaultVersion, say: "AnotherV1" });
+    });
+
+    it('should create a proxy for a modified contract if force is set', async function () {
+      await createProxy({ contractAlias, packageFileName, network, txParams, force: true });
+      const data = fs.parseJson(networkFileName);
+      await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
+    });
+  });
+  
 });

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -55,6 +55,15 @@ contract('create-proxy command', function([_, owner]) {
     await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
   });
 
+  it('should refuse to create a proxy for an undefined contract', async function() {
+    await createProxy({ contractAlias: "NotExists", packageFileName, network, txParams }).should.be.rejectedWith(/not found/);
+  });
+
+  it('should refuse to create a proxy for an undeployed contract', async function() {
+    await addImplementation({ contractName, contractAlias: "NotDeployed", packageFileName });
+    await createProxy({ contractAlias: "NotDeployed", packageFileName, network, txParams }).should.be.rejectedWith(/not deployed/);
+  });
+
   it('should be able to have multiple proxies for one of its contracts', async function() {
     await createProxy({ contractAlias, packageFileName, network, txParams });
     await createProxy({ contractAlias, packageFileName, network, txParams });
@@ -92,7 +101,7 @@ contract('create-proxy command', function([_, owner]) {
     });
 
     it('should refuse to create a proxy for a modified contract', async function () {
-      await createProxy({ contractAlias, packageFileName, network, txParams }).should.be.rejected;
+      await createProxy({ contractAlias, packageFileName, network, txParams }).should.be.rejectedWith(/has changed/);
     });
 
     it('should create a proxy for an unmodified contract', async function () {

--- a/test/scripts/upgrade-proxy.test.js
+++ b/test/scripts/upgrade-proxy.test.js
@@ -155,7 +155,7 @@ contract('upgrade-proxy command', function([_, owner]) {
   describe('with local modifications', function () {
     beforeEach("changing local network file to have a different bytecode", async function () {
       const data = fs.parseJson(networkFileName);
-      data.contracts["Impl"].bytecode = "0xabcd";
+      data.contracts["Impl"].bytecodeHash = "0xabcd";
       fs.writeJson(networkFileName, data);
     });
 

--- a/test/scripts/upgrade-proxy.test.js
+++ b/test/scripts/upgrade-proxy.test.js
@@ -37,8 +37,8 @@ contract('upgrade-proxy command', function([_, owner]) {
     await sync({ packageFileName, network, txParams });
     
     const networkDataV1 = fs.parseJson(networkFileName);
-    this.implV1Address = networkDataV1.contracts["Impl"];
-    this.anotherImplV1Address = networkDataV1.contracts["AnotherImpl"];
+    this.implV1Address = networkDataV1.contracts["Impl"].address;
+    this.anotherImplV1Address = networkDataV1.contracts["AnotherImpl"].address;
 
     await createProxy({ contractAlias: "Impl", packageFileName, network, txParams });
     await createProxy({ contractAlias: "Impl", packageFileName, network, txParams });
@@ -50,8 +50,8 @@ contract('upgrade-proxy command', function([_, owner]) {
     await sync({ packageFileName, network, txParams });
 
     const networkDataV2 = fs.parseJson(networkFileName);
-    this.implV2Address = networkDataV2.contracts["Impl"];
-    this.anotherImplV2Address = networkDataV2.contracts["AnotherImpl"];
+    this.implV2Address = networkDataV2.contracts["Impl"].address;
+    this.anotherImplV2Address = networkDataV2.contracts["AnotherImpl"].address;
   });
 
   after(cleanupfn(packageFileName));
@@ -145,22 +145,27 @@ contract('upgrade-proxy command', function([_, owner]) {
     await assertProxyInfo('Impl', 1, { version: v2string, implementation: this.implV2Address, value: 42 });
   });
 
+  it('should refuse to upgrade a proxy to an undeployed contract', async function() {
+    const data = fs.parseJson(networkFileName);
+    delete data.contracts["Impl"];
+    fs.writeJson(networkFileName, data);
+    await upgradeProxy({ contractAlias: "Impl", proxyAddress: null, network, packageFileName, txParams }).should.be.rejectedWith(/Impl are not deployed/)
+  });
+
   describe('with local modifications', function () {
     beforeEach("changing local network file to have a different bytecode", async function () {
       const data = fs.parseJson(networkFileName);
-      data.contracts[contractAlias].bytecode = "0xabcd";
+      data.contracts["Impl"].bytecode = "0xabcd";
       fs.writeJson(networkFileName, data);
     });
 
     it('should refuse to upgrade a proxy for a modified contract', async function () {
-      await upgradeProxy({ contractAlias, packageFileName, network, txParams }).should.be.rejected;
+      await upgradeProxy({ contractAlias: "Impl", packageFileName, network, txParams }).should.be.rejectedWith(/Impl have changed/);
     });
 
     it('should upgrade a proxy for a modified contract if force is set', async function () {
-      await upgradeProxy({ contractAlias, packageFileName, network, txParams, force: true });
-      const data = fs.parseJson(networkFileName);
-      const proxy = data.proxies[contractAlias][0];
-      proxy.version.should.eq(version);
+      await upgradeProxy({ contractAlias: "Impl", packageFileName, network, txParams, force: true });
+      await assertProxyInfo('Impl', 0, { version: v2string, implementation: this.implV2Address })
     });
   });
 });


### PR DESCRIPTION
This PR adds to the network package.zos file the bytecode of the
contract at the time it was deployed. It is then compared to the
bytecode of the contract locally before creating or upgrading a
proxy. If there was a change, then the command fails; this can be
overridden via a --force flag to either command.

Fixes #22.
