### PR TITLE
docs: follow conventions on example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ truffle init
 Initialize your project with zeppelin_os. The next command will create a new `package.zos.json` file:
 
 ```sh
-zos init [NAME] [VERSION] --network [NETWORK]
+zos init <name> <version> --network <network>
 ```
 For example:
 ```sh
@@ -83,13 +83,13 @@ npx truffle compile
 The next step is to register all the contract implementations of the first `version` of your project. To do this please run:
 
 ```
-zos add-implementation [CONTRACT_NAME_1] --network [NETWORK]
-zos add-implementation [CONTRACT_NAME_2] --network [NETWORK]
+zos add-implementation <contract_name_1> --network <network>
+zos add-implementation <contract_name_2> --network <network>
 ...
-zos add-implementation [CONTRACT_NAME_N] --network [NETWORK]
+zos add-implementation <contract_name_n> --network <network>
 ```
 
-Where `[CONTRACT_NAME]` is the name of your Solidity contract, and `[ALIAS]` is the name under which it will be registered 
+Where `<contract_name>` is the name of your Solidity contract, and `<alias>` is the name under which it will be registered 
 in zeppelin_os. 
 
 In our example, run:
@@ -103,7 +103,7 @@ To have your `package.zos.json` file always up-to-date, run `zos add-implementat
 
 This command will deploy your upgradeable application to the blockchain:
 ```
-zos sync --network [NETWORK]
+zos sync --network <network>
 ```
 
 The first time you run this command for a specific network, a new `package.zos.<network>.json` will be created. This file will reflect the status of your project in that network.
@@ -113,10 +113,10 @@ The first time you run this command for a specific network, a new `package.zos.<
 The next commands will deploy new proxies to make your contracts upgradeable:
 
 ```
-zos create-proxy [ALIAS_1] --network [NETWORK]
-zos create-proxy [ALIAS_2] --network [NETWORK]
+zos create-proxy <alias_1> --network <network>
+zos create-proxy <alias_2> --network <network>
 ...
-zos create-proxy [ALIAS_N] --network [NETWORK]
+zos create-proxy <alias_n> --network <network>
 ```
 
 Optionally, you can use the `-i` flag to call an initialization/migration function after you create the proxy.
@@ -135,13 +135,13 @@ Open the `package.zos.<network>.json` and use the addresses found there to inter
 In addition to creating proxies for your own contracts, you can also re-use already deployed contracts from a zeppelin_os standard library. To do so, run the following command, with the name of the npm package of the stdlib you want to use. For example:
 
 ```bash
-zos set-stdlib openzeppelin-zos --network [NETWORK]
+zos set-stdlib openzeppelin-zos --network <network>
 ```
 
 The next `sync` operation will connect your application with the chosen standard library on the target network. However, if you're using development nodes (such as testrpc or ganache), the standard library is not already deployed, since you are running from an empty blockchain. To work around this, you can add a `--deploy-stdlib` flag to the `sync` command:
 
 ```bash
-zos sync --network [NETWORK] --deploy-stdlib
+zos sync --network <network> --deploy-stdlib
 ```
 
 This will deploy your entire application to the target network, along with the standard library you are using and all its contracts. This way, you can transparently work in development with the contracts provided by the stdlib.
@@ -149,7 +149,7 @@ This will deploy your entire application to the target network, along with the s
 From there on, you can create proxies for any contract provided by the stdlib:
 
 ```bash
-zos create-proxy DetailedMintableToken --network [NETWORK]
+zos create-proxy DetailedMintableToken --network <network>
 ```
 
 
@@ -183,7 +183,7 @@ npx truffle compile
 We'll now use `zos` to register and deploy the new code for `MyContract` to the blockchain. Sync the new version of your project by running: 
 
 ```
-zos sync --network [NETWORK]
+zos sync --network <network>
 ```
 
 After running this command, the new versions of your project's contracts are deployed in the blockchain. 
@@ -191,16 +191,19 @@ However, the already deployed proxies are still running with the old implementat
 each of the proxies individually. To do so, you just need to run this for every contract: 
 
 ```
-zos upgrade-proxy [ALIAS_1] [PROXY_ADDRESS_1] --network [NETWORK]
-zos upgrade-proxy [ALIAS_2] [PROXY_ADDRESS_2] --network [NETWORK]
+zos upgrade-proxy <alias_1> <proxy_address_1> --network <network>
+zos upgrade-proxy <alias_2> <proxy_address_2> --network <network>
 ...
-zos upgrade-proxy [ALIAS_N] [PROXY_ADDRESS_N] --network [NETWORK]
+zos upgrade-proxy <alias_n> <proxy_address_n> --network <network>
 ```
 
 In our simple example:
 ```
-zos upgrade-proxy MyContract [PROXY_ADDRESS_FOUND_IN_PACKAGE_ZOS_NETWORK_JSON] --network development
+zos upgrade-proxy MyContract <proxy_address> --network development
 ```
+
+Where <proxy_address> is the address found in package.zos.<network>.json.
+  
 Voila! Your contract has now been upgraded. The address is the same as before, but the code has been changed to the latest version. Repeat the same steps for every code update you want to perform.
 
 ## <a name="testing"></a> Testing a `zos` upgradeable application
@@ -268,11 +271,11 @@ To fund development of a zOS Kernel standard library release, you can vouch your
 
 To vouch for the release you're using in your app, run:
 ```
-zos vouch [RELEASE_ADDRESS] [ZEP_AMOUNT_IN_UNITS] --from [ZEP_HOLDING_ADDRESS]
+zos vouch <release_address> <zep_amount_in_units> --from <zep_holding_address>
 ```
 If you want to stop supporting this release, run:
 ```
-zos unvouch [RELEASE_ADDRESS] [ZEP_AMOUNT_IN_UNITS] --from [ADDRESS_THAT_VOUCHED]
+zos unvouch <release_address> <zep_amount_in_units> --from <address_that_vouched>
 ```
 
 


### PR DESCRIPTION
The square brackets usually mean that the arguments are optional, so you would document something like:
`zos sync [--network <network>]` 
if there is a default network and the it is optional.

The upper case is usually used for environment variables.