### PR TITLE
Fail early and loudly in commands

### DIFF
--- a/src/commands/users/create-proxy.js
+++ b/src/commands/users/create-proxy.js
@@ -1,5 +1,8 @@
+import { Logger } from 'zos-lib'
 import createProxy from '../../scripts/create-proxy'
 import runWithTruffle from '../../utils/runWithTruffle'
+
+const log = new Logger('CreateProxy')
 
 module.exports = function(program) {
   program
@@ -21,6 +24,12 @@ module.exports = function(program) {
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
       const { from, network, force } = options
+
+      if (network === undefined) {
+        log.error('Must provide a network name')
+        return
+      }
+
       runWithTruffle(async () => await createProxy({ contractAlias, network, from, initMethod, initArgs, force }), network)
     })
 }

--- a/src/commands/users/sync.js
+++ b/src/commands/users/sync.js
@@ -1,5 +1,8 @@
+import { Logger } from 'zos-lib'
 import sync from '../../scripts/sync'
 import runWithTruffle from '../../utils/runWithTruffle'
+
+const log = new Logger('Sync')
 
 module.exports = function(program) {
   program
@@ -11,6 +14,12 @@ module.exports = function(program) {
     .option('--deploy-stdlib', 'Deploys a copy of the stdlib (if any) instead of using the one already published to the network by its author (useful in local testrpc networks)')
     .action(function (options) {
       const { from, network, deployStdlib } = options
+
+      if (network === undefined) {
+        log.error('Must provide a network name')
+        return
+      }
+
       runWithTruffle(async () => await sync({ network, from, deployStdlib }), network)
     })
 }

--- a/src/commands/users/upgrade-proxy.js
+++ b/src/commands/users/upgrade-proxy.js
@@ -1,5 +1,8 @@
+import { Logger } from 'zos-lib'
 import upgradeProxy from '../../scripts/upgrade-proxy'
 import runWithTruffle from '../../utils/runWithTruffle'
+
+const log = new Logger('UpdateProxy')
 
 module.exports = function(program) {
   program
@@ -22,6 +25,12 @@ module.exports = function(program) {
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
       const { from, network, all, force } = options
+
+      if (network === undefined) {
+        log.error('Must provide a network name')
+        return
+      }
+
       runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, network, from, initMethod, initArgs, all, force }), network)
     })
 }


### PR DESCRIPTION
Adding a few checks in `sync`, `create-proxy` and `upgrade-proxy`.
Without them, it fails in a late stage with misleading stacktraces.