### PR TITLE
Rename CLI commands

### DIFF
--- a/src/commands/users/add-implementation.js
+++ b/src/commands/users/add-implementation.js
@@ -4,15 +4,15 @@ import addAllImplementations from '../../scripts/add-all-implementations'
 
 module.exports = function(program) {
   program
-    .command('add-implementation [contractNames...]')
+    .command('add [contractNames...]')
     .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
-    .description(`Register contract implementations.
+    .description(`Add contract implementations to your project.
       Provide a list of [contractNames...] to be registered.
       Provide an alias to register your contract using the notation <contractName:contractAlias>.
       If no alias is provided, <contractName> will be used by default.`)
     .option('--all', 'Skip contract names option and set --all to add all the contracts of your build directory.')
-    .option('--sync <network>', 'Sync your project with the blockchain')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')
+    .option('--push <network>', 'Push your changes to the specified network')
+    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
     .action(function (contractNames, options) {
       if(options.all) addAllImplementations({})
       else {
@@ -22,6 +22,6 @@ module.exports = function(program) {
         })
         addImplementation({ contractsData })
       }
-      if(options.sync) sync.action({ network: options.sync, from: options.from })
+      if(options.push) sync.action({ network: options.push, from: options.from })
     })
 }

--- a/src/commands/users/create-proxy.js
+++ b/src/commands/users/create-proxy.js
@@ -3,9 +3,9 @@ import runWithTruffle from '../../utils/runWithTruffle'
 
 module.exports = function(program) {
   program
-    .command('create-proxy <alias>')
+    .command('create <alias>')
     .usage('<alias> --network <network> [options]')
-    .description(`Deploy a new proxy to make your contract upgradeable.
+    .description(`Creates a new proxy for the specified implementation.
       Provide the <alias> name you used to register your contract.`)
     .option('-i, --init [function]', "Tell whether your contract has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
     .option('-a, --args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')

--- a/src/commands/users/init.js
+++ b/src/commands/users/init.js
@@ -10,11 +10,11 @@ module.exports = function(program) {
       Provide a [version] number, otherwise 0.0.1 will be used by default.`)
     .option('-s, --stdlib <stdlib>', 'Standard library to use')
     .option('--no-install', 'Skip installing stdlib npm dependencies')
-    .option('--sync <network>', 'Sync your project with the blockchain')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')
+    .option('--push <network>', 'Push your changes to the specified network')
+    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
     .action(async function (name, version, options) {
       const { stdlib: stdlibNameVersion, install: installDeps } = options
       await init({ name, version, stdlibNameVersion, installDeps })
-      if(options.sync) sync.action({ network: options.sync, from: options.from })
+      if(options.push) sync.action({ network: options.push, from: options.from })
     })
 }

--- a/src/commands/users/new-version.js
+++ b/src/commands/users/new-version.js
@@ -3,16 +3,16 @@ import newVersion from '../../scripts/new-version'
 
 module.exports = function(program) {
   program
-    .command('new-version <version>')
+    .command('bump <version>')
     .usage('<version> [options]')
     .description("Bump a new <version> of your project with zeppelin_os.")
     .option('-s, --stdlib <stdlib>', 'Standard library to use')
     .option('--no-install', 'Skip installing stdlib npm dependencies')
-    .option('--sync <network>', 'Sync your project with the blockchain')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')
+    .option('--push <network>', 'Push your changes to the specified network')
+    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
     .action(async function (version, options) {
       const { stdlib: stdlibNameVersion, install: installDeps } = options
       await newVersion({ version, stdlibNameVersion, installDeps })
-      if(options.sync) sync.action({ network: options.sync, from: options.from })
+      if(options.push) sync.action({ network: options.push, from: options.from })
     })
 }

--- a/src/commands/users/set-stdlib.js
+++ b/src/commands/users/set-stdlib.js
@@ -3,15 +3,15 @@ import setStdlib from '../../scripts/set-stdlib'
 
 module.exports = function(program) {
   program
-    .command('set-stdlib <stdlib>')
+    .command('link <stdlib>')
     .usage('<stdlib> [options]')
-    .description("Set a standard library for your project.\n  Provide the npm package of the standard library under <stdlib>.")
+    .description("Links a standard library for your project.\n  Provide the npm package of the standard library under <stdlib>.")
     .option('--no-install', 'Skip installing stdlib npm dependencies')
-    .option('--sync <network>', 'Sync your project with the blockchain')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')
+    .option('--push <network>', 'Push your changes to the specified network')
+    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
     .action(async function (stdlibNameVersion, options) {
       const installDeps = options.install
       await setStdlib({ stdlibNameVersion, installDeps })
-      if(options.sync) sync.action({ network: options.sync, from: options.from })
+      if(options.push) sync.action({ network: options.push, from: options.from })
     })
 }

--- a/src/commands/users/sync.js
+++ b/src/commands/users/sync.js
@@ -3,8 +3,8 @@ import runWithTruffle from '../../utils/runWithTruffle'
 
 function registerSync(program) {
   program
-    .command('sync')
-    .description('Sync your project with the blockchain')
+    .command('push')
+    .description('Pushes your project to the specified network')
     .usage('--network <network> [options]')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')

--- a/src/commands/users/upgrade-proxy.js
+++ b/src/commands/users/upgrade-proxy.js
@@ -3,7 +3,7 @@ import runWithTruffle from '../../utils/runWithTruffle'
 
 module.exports = function(program) {
   program
-    .command('upgrade-proxy [alias] [address]')
+    .command('upgrade [alias] [address]')
     .usage('[alias] [address] --network <network> [options]')
     .description(`Upgrade a proxied contract to a new implementation.
       Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)


### PR DESCRIPTION
Applied the following renames:
- add-implementation => add
- create-proxy => create
- new-version => bump
- set-stdlib => link
- sync => push
- upgrade-proxy => upgrade

Changed the following flags:
- --sync => --push

Fixes #42 