### PR TITLE
Remove short opts for readability

### DIFF
--- a/src/commands/users/create-proxy.js
+++ b/src/commands/users/create-proxy.js
@@ -7,8 +7,8 @@ module.exports = function(program) {
     .usage('<alias> --network <network> [options]')
     .description(`Deploy a new proxy to make your contract upgradeable.
       Provide the <alias> name you used to register your contract.`)
-    .option('-i, --init [function]', "Tell whether your contract has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
-    .option('-a, --args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
+    .option('--init [function]', "Tell whether your contract has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
+    .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')
     .option('--force', 'Force creation of the proxy even if contracts have local modifications')

--- a/src/commands/users/init.js
+++ b/src/commands/users/init.js
@@ -8,7 +8,7 @@ module.exports = function(program) {
     .description(`Initialize your project with zeppelin_os.
       Provide a <project> name.
       Provide a [version] number, otherwise 0.0.1 will be used by default.`)
-    .option('-s, --stdlib <stdlib>', 'Standard library to use')
+    .option('--stdlib <stdlib>', 'Standard library to use')
     .option('--no-install', 'Skip installing stdlib npm dependencies')
     .option('--sync <network>', 'Sync your project with the blockchain')
     .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')

--- a/src/commands/users/new-version.js
+++ b/src/commands/users/new-version.js
@@ -6,7 +6,7 @@ module.exports = function(program) {
     .command('new-version <version>')
     .usage('<version> [options]')
     .description("Bump a new <version> of your project with zeppelin_os.")
-    .option('-s, --stdlib <stdlib>', 'Standard library to use')
+    .option('--stdlib <stdlib>', 'Standard library to use')
     .option('--no-install', 'Skip installing stdlib npm dependencies')
     .option('--sync <network>', 'Sync your project with the blockchain')
     .option('-f, --from <from>', 'Set the transactions sender in case you run with --sync')

--- a/src/commands/users/upgrade-proxy.js
+++ b/src/commands/users/upgrade-proxy.js
@@ -7,8 +7,8 @@ module.exports = function(program) {
     .usage('[alias] [address] --network <network> [options]')
     .description(`Upgrade a proxied contract to a new implementation.
       Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
-    .option('-i, --init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
-    .option('-a, --args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
+    .option('--init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
+    .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
     .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')


### PR DESCRIPTION
Removes the short version for opts that are not that frequent, in
order to improve readability of the commands used and avoid potential
mistakes from the users.

Removed the following short opts:
- -s for --stdlib
- -i for --init
- -a for --args