### PR TITLE
Add command to generate html documentation for zos-docs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
       "targets": {
         "node": "8.9"
       }
-    }]
+    }],
+    "react"
   ],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/docs/bin/docs.js
+++ b/docs/bin/docs.js
@@ -1,0 +1,44 @@
+#! /usr/bin/env node
+const program = require('../../src/bin/program');
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import Main from '../components/Main';
+import Command from '../components/Command';
+import path from 'path';
+import process from 'process';
+
+const outputPath = 'docs/build';
+
+function formatContent(id, title, content){
+  return `---
+id: ${id}
+title: ${title}
+---
+
+${content}
+`;
+}
+
+function writeMd(id, title, content) {
+  const data = formatContent(id, title, content);
+  writeFileSync(path.resolve(outputPath, `${id}.md`), data);
+}
+
+function run() {
+  if (!existsSync(outputPath)) {
+    mkdirSync(outputPath);
+  }
+
+  const main = renderToStaticMarkup(React.createElement(Main, { program }));
+  writeMd('main', 'Entrypoint', main);
+
+  program.commands.forEach(command => {
+    const content = renderToStaticMarkup(React.createElement(Command, { command }));
+    writeMd(command.name(), command.name(), content);
+  });
+}
+
+run();
+console.log(`Docs generated in ${process.cwd()}/${outputPath}`)

--- a/docs/components/Command.jsx
+++ b/docs/components/Command.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Usage, Options, Description } from './Shared';
+
+export default function Command({ command }) {
+  return (
+    <div className='cli-command'>
+      <h2 className='cli-title'>{command.name()}</h2>
+      <Usage name={command.name()} usage={command.usage()} />
+      <Description description={command.description()} />
+      <Options options={command.options} />
+    </div>
+  );
+}
+

--- a/docs/components/Main.jsx
+++ b/docs/components/Main.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Usage, Options } from './Shared';
+
+export default function Main({ program }) {
+  return (
+    <div className='cli-command'>
+      <h2 className='cli-title'>{program.name()}</h2>
+      <Usage name={program.name()} usage={program.usage()} />
+      <Options options={program.options} />
+      <Commands commands={program.commands} />
+    </div>
+  );
+}
+
+function Commands({ commands }) {
+  return null;  
+}

--- a/docs/components/Shared.jsx
+++ b/docs/components/Shared.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+export function Usage({ name, usage }) {
+  return (
+    <p className="cli-usage">
+      Usage: <code>{name} {usage}</code>
+    </p>
+  );
+}
+
+export function Options({ options }) {
+  return (
+    <dl>
+      <dt><span>Options:</span></dt>
+      <dd>
+      {options.map(option => (
+        <div key={option.flags}>
+          <code>{option.flags}</code> {option.description}
+        </div>
+      ))}
+      </dd>
+    </dl>
+  );
+}
+
+export function Description({ description }) {
+  return (
+    <p>
+      {description.split('\n').reduce((arr, line, i) => arr.concat([line, (<br key={i} />)]), [])}
+    </p>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,17 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
+      }
+    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -473,6 +484,12 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -786,6 +803,46 @@
         "babel-runtime": "^6.26.0"
       }
     },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -880,6 +937,29 @@
         "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
         "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
         "babel-plugin-transform-regenerator": "^6.24.1"
+      }
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       }
     },
     "babel-preset-stage-1": {
@@ -1877,6 +1957,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "enhanced-resolve": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
@@ -2498,6 +2587,29 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "optional": true
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
     },
     "figures": {
       "version": "2.0.0",
@@ -4470,6 +4582,16 @@
         "isarray": "1.0.0"
       }
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -5453,6 +5575,16 @@
         "lodash.toarray": "^4.4.0"
       }
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node-interval-tree": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/node-interval-tree/-/node-interval-tree-1.3.3.tgz",
@@ -5949,6 +6081,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promisify-node": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz",
@@ -5956,6 +6097,17 @@
       "requires": {
         "nodegit-promise": "~4.0.0",
         "object-assign": "^4.0.1"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "proxy-addr": {
@@ -6086,6 +6238,30 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
+      }
+    },
+    "react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "read-chunk": {
@@ -6662,6 +6838,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -7789,6 +7971,12 @@
         "mime-types": "~2.1.18"
       }
     },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+      "dev": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -8253,6 +8441,12 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "whatwg-url-compat": {
       "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "prepack": "truffle compile && babel src --out-dir lib",
-    "test": "NODE_ENV=test ./node_modules/.bin/truffle test"
+    "test": "NODE_ENV=test ./node_modules/.bin/truffle test",
+    "gen-docs": "babel-node docs/bin/docs.js"
   },
   "bin": {
     "zos": "./lib/bin/zos-cli.js"
@@ -48,6 +49,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",
@@ -55,6 +57,8 @@
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
     "mock-stdlib": "file:test/mocks/mock-stdlib",
-    "mock-stdlib-2": "file:test/mocks/mock-stdlib-2"
+    "mock-stdlib-2": "file:test/mocks/mock-stdlib-2",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   }
 }

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -1,0 +1,17 @@
+const program = require('commander')
+const { version } = require('../../package.json')
+const registerUserCommands = require('./users')
+const registerDeveloperCommands = require('./developers')
+const registerErrorHandler = require('./errors')
+
+program
+  .name('zos')
+  .usage('<command> [options]')
+  .version(version, '--version')
+  .option('-v, --verbose', 'Switch verbose mode on. Output errors stacktrace.')
+
+registerUserCommands(program)
+registerDeveloperCommands(program)
+registerErrorHandler(program)
+
+module.exports = program;

--- a/src/bin/zos-cli.js
+++ b/src/bin/zos-cli.js
@@ -1,18 +1,2 @@
 #! /usr/bin/env node
-
-const program = require('commander')
-const { version } = require('../../package.json')
-const registerUserCommands = require('./users')
-const registerDeveloperCommands = require('./developers')
-const registerErrorHandler = require('./errors')
-
-program
-  .usage('<command> [options]')
-  .version(version, '--version')
-  .option('-v, --verbose', 'Switch verbose mode on. Output errors stacktrace.')
-
-registerUserCommands(program)
-registerDeveloperCommands(program)
-registerErrorHandler(program)
-
-program.parse(process.argv)
+require('./program').parse(process.argv)


### PR DESCRIPTION
Uses react templating to generate md files with html to be used
in the zos-docs project. React is not included as a dependency but
as a dev dependency, and the project should not include docs when
packaged.

Run it via `npm run gen-docs`