### PR TITLE
Integrate new logger and log data to stdout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9612,9 +9612,9 @@
       "integrity": "sha512-pdyPVyjDq7cNqqLps9juDNDkKCa6hSafEm8KyzPw+gNYTiDyG1H4sYVFuBGp03iqxlGhsacrstbps5/AHTxBUg=="
     },
     "zos-lib": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-0.1.19.tgz",
-      "integrity": "sha512-eN3bhj5bXPdehjph+IVrV2GiqW36K9qI0SO3/Stm42DsuHWoQK+7qNPnm0QMBFmsjBErbK02DcRI0SHQnzFBmA==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-0.1.20.tgz",
+      "integrity": "sha512-ynOrDxMGT0fLZPHyCRK0Ct1eQxC2pNxuVutSQNCyjntCnLkUwn5O1Ap1Lf02kzG88l2V4NlIQulBQEiikpWKHA==",
       "requires": {
         "fs": "0.0.1-security",
         "truffle-contract": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "truffle-contract": "^3.0.5",
     "truffle-core": "^4.1.8",
     "truffle-workflow-compile": "^1.0.3",
-    "zos-lib": "^0.1.19"
+    "zos-lib": "^0.1.20"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -1,6 +1,7 @@
 const program = require('commander')
 const { version } = require('../../package.json')
 const registerErrorHandler = require('./errors')
+const Logger = require('zos-lib').Logger;
 
 const init = require('../commands/users/init')
 const addImplementation = require('../commands/users/add-implementation')
@@ -15,7 +16,10 @@ program
   .name('zos')
   .usage('<command> [options]')
   .version(version, '--version')
-  .option('-v, --verbose', 'Switch verbose mode on. Output errors stacktrace.')
+  .option('-v, --verbose', 'Verbose mode. Output errors stacktrace and detailed log.')
+  .option('-s, --silent', 'Silent mode. Do not output anything to stderr.')
+  .on('option:verbose', () => { Logger.verbose(true); } )
+  .on('option:silent', () => { Logger.silent(true); } )
 
 init(program)
 addImplementation(program)

--- a/src/bin/zos-cli.js
+++ b/src/bin/zos-cli.js
@@ -1,2 +1,3 @@
 #! /usr/bin/env node
+require('zos-lib').Logger.silent(false)
 require('./program').parse(process.argv)

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -21,6 +21,10 @@ export default class NetworkBaseController {
     throw Error("Unimplemented function isDeployed()");
   }
 
+  get packageAddress() {
+    return this.networkPackage.package && this.networkPackage.package.address;
+  }
+
   async push(reupload = false) {
     await this.init()
     await this.pushVersion()

--- a/src/models/network/NetworkLibController.js
+++ b/src/models/network/NetworkLibController.js
@@ -12,10 +12,6 @@ export default class NetworkLibController extends NetworkBaseController {
     return { contracts: {}, lib: true };
   }
 
-  get packageAddress() {
-    return this.networkPackage.package && this.networkPackage.package.address;
-  }
-
   isDeployed() {
     return !!this.packageAddress;
   }

--- a/src/scripts/bump-version.js
+++ b/src/scripts/bump-version.js
@@ -1,4 +1,5 @@
 import ControllerFor from  '../models/local/ControllerFor'
+import stdout from '../utils/stdout';
 
 export default async function bumpVersion({ version, stdlibNameVersion = undefined, installDeps = false, packageFileName = undefined }) {
   if (version === undefined || version === '') throw Error('A version name must be provided to initialize a new version.')
@@ -14,4 +15,5 @@ export default async function bumpVersion({ version, stdlibNameVersion = undefin
   }
 
   appController.writePackage()
+  stdout(version)
 }

--- a/src/scripts/create-proxy.js
+++ b/src/scripts/create-proxy.js
@@ -1,4 +1,5 @@
 import LocalAppController from '../models/local/LocalAppController';
+import stdout from '../utils/stdout';
 
 export default async function createProxy({ contractAlias, initMethod, initArgs, network, txParams = {}, packageFileName = undefined, networkFileName = undefined, force = false }) {
   if (!contractAlias) throw Error('A contract alias must be provided to create a new proxy.')
@@ -6,6 +7,8 @@ export default async function createProxy({ contractAlias, initMethod, initArgs,
   const appController = new LocalAppController(packageFileName).onNetwork(network, txParams, networkFileName);
   await appController.checkLocalContractDeployed(contractAlias, !force);
   const proxy = await appController.createProxy(contractAlias, initMethod, initArgs);
+
   appController.writeNetworkPackage();
+  stdout(proxy.address);
   return proxy;
 }

--- a/src/scripts/link-stdlib.js
+++ b/src/scripts/link-stdlib.js
@@ -1,4 +1,5 @@
 import ControllerFor from "../models/local/ControllerFor";
+import stdout from '../utils/stdout';
 
 export default async function linkStdlib({ stdlibNameVersion, installDeps = false, packageFileName = undefined }) {
   if (!stdlibNameVersion) {
@@ -10,4 +11,5 @@ export default async function linkStdlib({ stdlibNameVersion, installDeps = fals
   }
   await appController.linkStdlib(stdlibNameVersion, installDeps)
   appController.writePackage()
+  stdout(stdlibNameVersion)
 }

--- a/src/scripts/push.js
+++ b/src/scripts/push.js
@@ -1,4 +1,5 @@
 import ControllerFor from "../models/local/ControllerFor";
+import stdout from '../utils/stdout';
 
 export default async function push({ network, deployStdlib, reupload = false, txParams = {}, packageFileName = undefined, networkFileName = undefined }) {
   const appController = ControllerFor(packageFileName).onNetwork(network, txParams, networkFileName);
@@ -8,4 +9,5 @@ export default async function push({ network, deployStdlib, reupload = false, tx
   }
   await appController.push(reupload);
   appController.writeNetworkPackage();
+  stdout(appController.isLib() ? appController.packageAddress : appController.appAddress);
 }

--- a/src/scripts/upgrade-proxy.js
+++ b/src/scripts/upgrade-proxy.js
@@ -1,4 +1,6 @@
 import LocalAppController from "../models/local/LocalAppController";
+import stdout from '../utils/stdout';
+import _ from 'lodash';
 
 export default async function upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, all, network, txParams = {}, packageFileName = undefined, networkFileName = undefined, force = false }) {
   if (!contractAlias && !all) {
@@ -7,6 +9,7 @@ export default async function upgradeProxy({ contractAlias, proxyAddress, initMe
 
   const appController = new LocalAppController(packageFileName).onNetwork(network, txParams, networkFileName);
   await appController.checkLocalContractsDeployed(!force);
-  await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
+  const proxies = await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
   appController.writeNetworkPackage();
+  _(proxies).values().forEach(proxy => stdout(proxy.address));
 }

--- a/src/utils/stdout.js
+++ b/src/utils/stdout.js
@@ -1,0 +1,13 @@
+const state = {
+  silent: false
+}
+
+export default function log() {
+  if (!state.silent && process.env.NODE_ENV !== 'test') {
+    console.log(...arguments);
+  }
+}
+
+export function silent(value) {
+  state.silent = value;
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,19 +1,12 @@
-import { Logger } from 'zos-lib'
 import Stdlib from '../src/models/stdlib/Stdlib'
 import StdlibInstaller from '../src/models/stdlib/StdlibInstaller'
 
-muteLogging()
 doNotInstallStdlib()
 
 require('chai')
   .use(require('chai-as-promised'))
   .use(require('./helpers/assertions'))
   .should()
-
-function muteLogging() {
-  Logger.prototype.info = msg => {}
-  Logger.prototype.error = msg => {}
-}
 
 function doNotInstallStdlib() {
   StdlibInstaller.call = stdlibNameAndVersion => new Stdlib(stdlibNameAndVersion)

--- a/truffle.js
+++ b/truffle.js
@@ -6,7 +6,8 @@ module.exports = {
     local: {
       host: 'localhost',
       port: 8545,
-      network_id: '*'
+      network_id: '*',
+      gas: 5000000
     }
   }
 }


### PR DESCRIPTION
Use new logger from lib which is silent by default, and pass through verbose and silent flags. Send data from commands to stdout when appropriate. Fixes #107.