### PR TITLE
Check constructor, initialize, and migrate

### DIFF
--- a/contracts/mocks/ImplV1.sol
+++ b/contracts/mocks/ImplV1.sol
@@ -18,3 +18,9 @@ contract AnotherImplV1 is ImplV1 {
     return "AnotherV1";
   }
 }
+
+contract UninitializableImplV1 {
+  function say() public pure returns (string) {
+    return "UninitializableImplV1";
+  }
+}

--- a/contracts/mocks/ImplV1.sol
+++ b/contracts/mocks/ImplV1.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.21;
 
 contract ImplV1 {
-
   uint256 public value;
 
   function initialize(uint256 _value) public {

--- a/contracts/mocks/Invalid.sol
+++ b/contracts/mocks/Invalid.sol
@@ -1,0 +1,11 @@
+contract WithConstructor {
+  uint256 public value;
+
+  function WithConstructor() {
+    value = 42;
+  }
+
+  function say() pure returns (string) {
+    return "WithConstructor";
+  }
+}

--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -33,6 +33,13 @@ export default class LocalBaseController {
   }
 
   addImplementation(contractAlias, contractName) {
+    // We are logging an error instead of throwing because a contract may have an empty constructor, 
+    // which is fine, but as long as it is declared we will be picking it up
+    const path = `${process.cwd()}/build/contracts/${contractName}.json`
+    if (this.hasConstructor(path)) {
+      log.error(`Contract ${contractName} has an explicit constructor. Consider changing it into an initializer to use with ZeppelinOS.`)
+    }
+
     this.packageData.contracts[contractAlias] = contractName;
   }
 
@@ -65,6 +72,12 @@ export default class LocalBaseController {
     if (!fs.exists(contractDataPath)) return false
     const bytecode = fs.parseJson(contractDataPath).bytecode
     return bytecode && bytecode !== "0x"
+  }
+
+  hasConstructor(contractDataPath) {
+    if (!fs.exists(contractDataPath)) return false
+    const abi = fs.parseJson(contractDataPath).abi
+    return !!abi.find(fn => fn.type === "constructor");
   }
 
   get packageData() {

--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -37,7 +37,7 @@ export default class LocalBaseController {
     // which is fine, but as long as it is declared we will be picking it up
     const path = `${process.cwd()}/build/contracts/${contractName}.json`
     if (this.hasConstructor(path)) {
-      log.error(`Contract ${contractName} has an explicit constructor. Consider changing it into an initializer to use with ZeppelinOS.`)
+      log.error(`Contract ${contractName} has an explicit constructor. Move it to an initializer function to use it with ZeppelinOS.`)
     }
 
     this.packageData.contracts[contractAlias] = contractName;

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -87,7 +87,7 @@ export default class NetworkAppController extends NetworkBaseController {
     // Otherwise, warn the user to invoke it
     const initializeMethod = contractClass.abi.find(fn => fn.type === 'function' && fn.name === 'initialize');
     if (!initializeMethod) return;
-    log.error(`Possible initialization method 'initialize' found in contract. Consider initializing the proxy after creating it.`);
+    log.error(`Possible initialization method 'initialize' found in contract. Make sure you initialize your instance.`);
   }
 
   async upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs) {
@@ -140,7 +140,7 @@ export default class NetworkAppController extends NetworkBaseController {
     // Otherwise, warn the user to invoke it
     const migrateMethod = contractClass.abi.find(fn => fn.type === 'function' && fn.name === 'migrate');
     if (!migrateMethod) return;
-    log.error(`Possible migration method 'migrate' found in contract ${contractClass.contractName}. Consider migrating the proxy after creating it.`);
+    log.error(`Possible migration method 'migrate' found in contract ${contractClass.contractName}. Remember running the migration after deploying it.`);
   }
 
   async linkStdlib() {

--- a/src/scripts/upgrade-proxy.js
+++ b/src/scripts/upgrade-proxy.js
@@ -11,5 +11,5 @@ export default async function upgradeProxy({ contractAlias, proxyAddress, initMe
   await appController.checkLocalContractsDeployed(!force);
   const proxies = await appController.upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs);
   appController.writeNetworkPackage();
-  _(proxies).values().forEach(proxy => stdout(proxy.address));
+  _(proxies).values().forEach(proxies => proxies.forEach(proxy => stdout(proxy.address)));
 }

--- a/test/helpers/captureLogs.js
+++ b/test/helpers/captureLogs.js
@@ -1,0 +1,17 @@
+import { Logger } from 'zos-lib';
+
+export default class CaptureLogs {
+  constructor() {
+    this.infos = [];
+    this.errors = [];
+    this.origError = Logger.prototype.error;
+    this.origInfo = Logger.prototype.info;
+    Logger.prototype.error = (msg) => { this.errors.push(msg); }
+    Logger.prototype.info = (msg) => { this.infos.push(msg); }
+  }
+
+  restore() {
+    Logger.prototype.error = this.origError;
+    Logger.prototype.info = this.origInfo;
+  }
+}

--- a/test/scripts/add-implementation.test.js
+++ b/test/scripts/add-implementation.test.js
@@ -6,6 +6,7 @@ import addImplementation from "../../src/scripts/add-implementation.js";
 import { cleanup, cleanupfn } from "../helpers/cleanup.js";
 import { FileSystem as fs, Logger } from 'zos-lib';
 import { editJson } from '../helpers/json.js';
+import CaptureLogs from '../helpers/captureLogs';
 
 contract('add-implementation command', function() {
   const packageFileName = "test/tmp/zos.json";
@@ -83,20 +84,22 @@ contract('add-implementation command', function() {
 
   describe('warnings', function () {
     beforeEach('capturing log output', function () {
-      const errors = [];
-      this.errors = errors;
-      Logger.prototype.error = (msg) => errors.push(msg);
+      this.logs = new CaptureLogs();
+    });
+
+    afterEach(function () {
+      this.logs.restore();
     });
 
     it('should warn when adding a contract with a constructor', async function() {
       addImplementation({ contractsData: [{ name: "WithConstructor", alias: "WithConstructor" }], packageFileName});
-      this.errors.should.have.lengthOf(1);
-      this.errors[0].should.match(/constructor/i);
+      this.logs.errors.should.have.lengthOf(1);
+      this.logs.errors[0].should.match(/constructor/i);
     });
 
     it('should not warn when adding a contract without a constructor', async function() {
       addImplementation({ contractsData, packageFileName});
-      this.errors.should.have.lengthOf(0);
+      this.logs.errors.should.have.lengthOf(0);
     });
   });
 });

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -4,7 +4,7 @@ require('../setup')
 import init from "../../src/scripts/init.js";
 import push from "../../src/scripts/push.js";
 import { cleanup, cleanupfn } from "../helpers/cleanup.js";
-import { FileSystem as fs } from "zos-lib";
+import { FileSystem as fs, Logger } from "zos-lib";
 import { editJson } from '../helpers/json.js';
 import createProxy from "../../src/scripts/create-proxy.js";
 import addImplementation from "../../src/scripts/add-implementation.js";
@@ -14,13 +14,20 @@ import LocalAppController from '../../src/models/local/LocalAppController';
 const ImplV1 = artifacts.require('ImplV1');
 
 contract('create-proxy command', function([_, owner]) {
-  const txParams = { from: owner };
-  const appName = "MyApp";
   const contractName = "ImplV1";
   const contractAlias = "Impl";
   const anotherContractName = "AnotherImplV1";
   const anotherContractAlias = "AnotherImpl";
-  const contractsData = [{ name: contractName, alias: contractAlias}, { name: anotherContractName, alias: anotherContractAlias }]
+  const uninitializableContractName = "UninitializableImplV1";
+  const uninitializableContractAlias = "UninitializableImpl";
+  const contractsData = [
+    { name: contractName, alias: contractAlias}, 
+    { name: anotherContractName, alias: anotherContractAlias },
+    { name: uninitializableContractName, alias: uninitializableContractAlias }
+  ];
+
+  const txParams = { from: owner };
+  const appName = "MyApp";
   const defaultVersion = "0.1.0";
   const network = "test";
   const packageFileName = "test/tmp/zos.json";
@@ -88,6 +95,36 @@ contract('create-proxy command', function([_, owner]) {
     const data = fs.parseJson(networkFileName);
     await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
     await assertProxy(data.proxies[anotherContractAlias][0], { version: defaultVersion, say: "AnotherV1" });
+  });
+
+  describe('warnings', function () {
+    beforeEach('capturing log output', function () {
+      const errors = [];
+      this.errors = errors;
+      Logger.prototype.error = (msg) => errors.push(msg);
+    });
+
+    it('should warn when not initializing a contract with initialize method', async function() {
+      await createProxy({ contractAlias, packageFileName, network, txParams });
+      this.errors.should.have.lengthOf(1);
+      this.errors[0].should.match(/consider initializing/i);
+    });
+
+    it('should warn when not initializing a contract that inherits from one with an initialize method', async function() {
+      await createProxy({ contractAlias: anotherContractAlias, packageFileName, network, txParams });
+      this.errors.should.have.lengthOf(1);
+      this.errors[0].should.match(/consider initializing/i);
+    });
+
+    it('should not warn when initializing a contract', async function() {
+      await createProxy({ contractAlias, packageFileName, network, txParams, initMethod: 'initialize', initArgs: [42] });
+      this.errors.should.have.lengthOf(0);
+    });
+
+    it('should not warn when a contract has not initialize method', async function() {
+      await createProxy({ contractAlias: uninitializableContractAlias, packageFileName, network, txParams });
+      this.errors.should.have.lengthOf(0);
+    });
   });
 
   describe('with stdlib', function () {

--- a/test/scripts/upgrade-proxy.test.js
+++ b/test/scripts/upgrade-proxy.test.js
@@ -9,6 +9,7 @@ import createProxy from "../../src/scripts/create-proxy.js";
 import upgradeProxy from "../../src/scripts/upgrade-proxy.js";
 import { Contracts, FileSystem as fs, Logger } from "zos-lib";
 import { cleanupfn } from "../helpers/cleanup.js";
+import CaptureLogs from '../helpers/captureLogs';
 
 const ImplV1 = artifacts.require('ImplV1');
 const ImplV2 = artifacts.require('ImplV2');
@@ -169,26 +170,28 @@ contract('upgrade-proxy command', function([_, owner]) {
 
     describe('warnings', function () {
       beforeEach('capturing log output', function () {
-        const errors = [];
-        this.errors = errors;
-        Logger.prototype.error = (msg) => errors.push(msg);
+        this.logs = new CaptureLogs();
+      });
+  
+      afterEach(function () {
+        this.logs.restore();
       });
   
       it('should warn when not migrating a contract with migrate method', async function() {
         await upgradeProxy({ contractAlias: "Impl", packageFileName, network, txParams });
-        this.errors.should.have.lengthOf(1);
-        this.errors[0].should.match(/consider migrating/i);
+        this.logs.errors.should.have.lengthOf(1);
+        this.logs.errors[0].should.match(/remember running the migration/i);
       });
   
       it('should warn when not migrating a contract that inherits from one with a migrate method', async function() {
         await upgradeProxy({ contractAlias: "AnotherImpl", packageFileName, network, txParams });
-        this.errors.should.have.lengthOf(1);
-        this.errors[0].should.match(/consider migrating/i);
+        this.logs.errors.should.have.lengthOf(1);
+        this.logs.errors[0].should.match(/remember running the migration/i);
       });
   
       it('should not warn when migrating a contract', async function() {
         await upgradeProxy({ contractAlias: "Impl", packageFileName, network, txParams, initMethod: 'migrate', initArgs: [42] });
-        this.errors.should.have.lengthOf(0);
+        this.logs.errors.should.have.lengthOf(0);
       });
   
       it('should not warn when a contract has no migrate method', async function() {
@@ -196,7 +199,7 @@ contract('upgrade-proxy command', function([_, owner]) {
         await push({ packageFileName, network, txParams });
 
         await upgradeProxy({ contractAlias: "NoMigrate", packageFileName, network, txParams });
-        this.errors.should.have.lengthOf(0);
+        this.logs.errors.should.have.lengthOf(0);
       });
     });
   });


### PR DESCRIPTION
Checks whether an implementation has a constructor when adding it, an `initialize` method when creating a proxy for it (and not calling it), or a `migrate` method when upgrading it (and not calling it). Shows an error message in all cases, but does not halt execution, since there may be false positives (empty constructors, methods called initialize which are not initializers, migrations already called, etc).

Fixes #145 