### PR TITLE
Add implementation address in proxy information

### DIFF
--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -64,10 +64,12 @@ export default class NetworkAppController extends NetworkBaseController {
     await this.fetch();
     const contractClass = this.localController.getContractClass(contractAlias);
     const proxyInstance = await this.app.createProxy(contractClass, contractAlias, initMethod, initArgs);
-    
+    const implementationAddress = await this.app.getImplementation(contractAlias);
+
     const proxyInfo = {
       address: proxyInstance.address,
-      version: this.app.version
+      version: this.app.version,
+      implementation: implementationAddress
     };
 
     const proxies = this.networkPackage.proxies;
@@ -90,7 +92,9 @@ export default class NetworkAppController extends NetworkBaseController {
       const contractClass = this.localController.getContractClass(contractAlias);
       return _.map(contractProxyInfos, async (proxyInfo) => {        
         await this.app.upgradeProxy(proxyInfo.address, contractClass, contractAlias, initMethod, initArgs);
+        const implementationAddress = await this.app.getImplementation(contractAlias);
         proxyInfo.version = newVersion;
+        proxyInfo.implementation = implementationAddress;
       });
     }));
 

--- a/test/scripts/create-proxy.test.js
+++ b/test/scripts/create-proxy.test.js
@@ -9,6 +9,7 @@ import { editJson } from '../helpers/json.js';
 import createProxy from "../../src/scripts/create-proxy.js";
 import addImplementation from "../../src/scripts/add-implementation.js";
 import linkStdlib from "../../src/scripts/link-stdlib.js";
+import LocalAppController from '../../src/models/local/LocalAppController';
 
 const ImplV1 = artifacts.require('ImplV1');
 
@@ -36,7 +37,7 @@ contract('create-proxy command', function([_, owner]) {
   after(cleanupfn(packageFileName))
   after(cleanupfn(networkFileName))
 
-  const assertProxy = async function(proxyInfo, { version, say }) {
+  const assertProxy = async function(proxyInfo, { version, say, implementation }) {
     proxyInfo.address.should.be.nonzeroAddress;
     proxyInfo.version.should.eq(version);
 
@@ -45,12 +46,17 @@ contract('create-proxy command', function([_, owner]) {
       const said = await proxy.say();
       said.should.eq(say);
     }
+
+    if (implementation) {
+      proxyInfo.implementation.should.eq(implementation);
+    }
   }
 
   it('should create a proxy for one of its contracts', async function() {
     await createProxy({ contractAlias, packageFileName, network, txParams });
     const data = fs.parseJson(networkFileName);
-    await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1" });
+    const implementation = data.contracts[contractAlias].address;
+    await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: "V1", implementation });
   });
 
   it('should refuse to create a proxy for an undefined contract', async function() {

--- a/test/scripts/upgrade-proxy.test.js
+++ b/test/scripts/upgrade-proxy.test.js
@@ -43,6 +43,7 @@ contract('upgrade-proxy command', function([_, owner]) {
       const app = PackagedApp.at(data.app.address)
       const actualImplementation = await app.getProxyImplementation(proxyInfo.address)
       actualImplementation.should.eq(implementation);
+      proxyInfo.implementation.should.eq(implementation);
     }
 
     if (version)  {


### PR DESCRIPTION
Address is retrieved via `App.getImplementation`. There is a race condition if the app is being updated while the proxy is being created, but it is quite unlikely (and the CLI may probably break in other ways upon concurrent executions).

Fixes #153