### PR TITLE
Improve help 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,9 +84,12 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "any-observable": {
       "version": "0.2.0",
@@ -263,6 +266,30 @@
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "babel-core": {
@@ -1474,21 +1501,27 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -5191,6 +5224,23 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -5207,6 +5257,11 @@
           "requires": {
             "chalk": "^1.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -5230,6 +5285,23 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -5251,6 +5323,11 @@
           "requires": {
             "chalk": "^1.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -5265,6 +5342,23 @@
         "figures": "^1.7.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -5295,6 +5389,11 @@
             "exit-hook": "^1.0.0",
             "onetime": "^1.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -6204,6 +6303,23 @@
         "object-assign": "^4.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -6225,6 +6341,11 @@
             "exit-hook": "^1.0.0",
             "onetime": "^1.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/zeppelinos/zos-cli#readme",
   "dependencies": {
+    "chalk": "^2.4.1",
     "colors": "^1.2.1",
     "commander": "^2.15.1",
     "ethereumjs-abi": "^0.6.5",

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -31,7 +31,6 @@ program
 const commands = [init, add, push, create, bump, upgrade, link, status, freeze]
 
 commands.forEach((c) => {
-  if (c.setup)
   c.setup(program)
 });
 

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -1,36 +1,46 @@
+'use strict';
+
 const program = require('commander')
 const { version } = require('../../package.json')
 const registerErrorHandler = require('./errors')
 const Logger = require('zos-lib').Logger;
 
 const init = require('../commands/init')
-const addImplementation = require('../commands/add-implementation')
+const add = require('../commands/add-implementation')
 const push = require('../commands/push')
-const createProxy = require('../commands/create-proxy')
-const bumpVersion = require('../commands/bump-version')
-const upgradeProxy = require('../commands/upgrade-proxy')
-const linkStdlib = require('../commands/link-stdlib')
-const freeze = require('../commands/freeze')
+const create = require('../commands/create-proxy')
+const bump = require('../commands/bump-version')
+const upgrade = require('../commands/upgrade-proxy')
+const link = require('../commands/link-stdlib')
 const status = require('../commands/status')
+const freeze = require('../commands/freeze')
 
 program
   .name('zos')
   .usage('<command> [options]')
+  .description('where <command> is one of:\n' +
+          '\t add, bump, create, init, link, push, status, upgrade.')
   .version(version, '--version')
-  .option('-v, --verbose', 'Verbose mode. Output errors stacktrace and detailed log.')
-  .option('-s, --silent', 'Silent mode. Do not output anything to stderr.')
+  .option('-v, --verbose', 'verbose mode on: output errors stacktrace and detailed log.')
+  .option('-s, --silent', 'silent mode: no output sent to stderr.')
   .on('option:verbose', () => { Logger.verbose(true); } )
   .on('option:silent', () => { Logger.silent(true); } )
+  .option('-v, --verbose', 'switch verbose mode on')
 
-init(program)
-addImplementation(program)
-push(program)
-createProxy(program)
-bumpVersion(program)
-upgradeProxy(program)
-linkStdlib(program)
-freeze(program)
-status(program)
+
+const commands = [init, add, push, create, bump, upgrade, link, status, freeze]
+
+commands.forEach((c) => {
+  if (c.setup)
+  c.setup(program)
+});
+
+program.on('--help', function(){
+  commands.forEach((c) => {
+    console.log('    '+c.signature+'\t'+c.description)
+  });
+  console.log('');
+});
 
 registerErrorHandler(program)
 

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -34,7 +34,7 @@ commands.forEach((c) => c.register(program));
 const maxSig = Math.max(...commands.map(c => c.signature.length))
 program.on('--help', function(){
   commands.forEach((c) => {
-    console.log('    '+chalk.bold(c.signature.padEnd(maxSig))+'\t'+c.description)
+    console.log(`    ${chalk.bold(c.signature.padEnd(maxSig))}\t${c.description}`)
   });
   console.log('');
 });

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -29,9 +29,7 @@ program
 
 const commands = [init, add, push, create, bump, upgrade, link, status, freeze]
 
-commands.forEach((c) => {
-  c.setup(program)
-});
+commands.forEach((c) => c.register(program));
 
 const maxSig = Math.max(...commands.map(c => c.signature.length))
 program.on('--help', function(){

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -25,8 +25,6 @@ program
   .option('-s, --silent', 'silent mode: no output sent to stderr.')
   .on('option:verbose', () => { Logger.verbose(true); } )
   .on('option:silent', () => { Logger.silent(true); } )
-  .option('-v, --verbose', 'switch verbose mode on')
-
 
 const commands = [init, add, push, create, bump, upgrade, link, status, freeze]
 

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -34,7 +34,7 @@ commands.forEach((c) => c.register(program));
 const maxSig = Math.max(...commands.map(c => c.signature.length))
 program.on('--help', function(){
   commands.forEach((c) => {
-    console.log(`    ${chalk.bold(c.signature.padEnd(maxSig))}\t${c.description}`)
+    console.log(`    ${chalk.bold(c.signature.padEnd(maxSig))}\t${c.description}\n`)
   });
   console.log('');
 });

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -4,6 +4,7 @@ const program = require('commander')
 const { version } = require('../../package.json')
 const registerErrorHandler = require('./errors')
 const Logger = require('zos-lib').Logger;
+const chalk = require('chalk')
 
 const init = require('../commands/init')
 const add = require('../commands/add-implementation')
@@ -32,9 +33,11 @@ commands.forEach((c) => {
   c.setup(program)
 });
 
+const maxSig = Math.max(...commands.map(c => c.signature.length))
+console.log(maxSig)
 program.on('--help', function(){
   commands.forEach((c) => {
-    console.log('    '+c.signature+'\t'+c.description)
+    console.log('    '+chalk.bold(c.signature.padEnd(maxSig))+'\t'+c.description)
   });
   console.log('');
 });

--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -34,7 +34,6 @@ commands.forEach((c) => {
 });
 
 const maxSig = Math.max(...commands.map(c => c.signature.length))
-console.log(maxSig)
 program.on('--help', function(){
   commands.forEach((c) => {
     console.log('    '+chalk.bold(c.signature.padEnd(maxSig))+'\t'+c.description)

--- a/src/commands/add-implementation.js
+++ b/src/commands/add-implementation.js
@@ -8,7 +8,7 @@ const signature = 'add [contractNames...]'
 const description = 'add contract implementations to your project. Provide a list of contract names'
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')

--- a/src/commands/add-implementation.js
+++ b/src/commands/add-implementation.js
@@ -4,18 +4,18 @@ import push from './push'
 import addImplementation from '../scripts/add-implementation'
 import addAllImplementations from '../scripts/add-all-implementations'
 
+const signature = 'add [contractNames...]'
+const description = 'add contract implementations to your project. Provide a list of contract names'
 module.exports = {
+  signature, description,
   setup: function(program) {
     program
-      .command('add [contractNames...]', {noHelp: true})
+      .command(signature, {noHelp: true})
       .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
-      .description(`Add contract implementations to your project.
-        Provide a list of [contractNames...] to be registered.
-        Provide an alias to register your contract using the notation <contractName:contractAlias>.
-        If no alias is provided, <contractName> will be used by default.`)
-      .option('--all', 'Skip contract names option and set --all to add all the contracts of your build directory.')
-      .option('--push <network>', 'Push your changes to the specified network')
-      .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
+      .description(description)
+      .option('--all', 'add all contracts in your build directory')
+      .option('--push <network>', 'push changes to the specified network after adding')
+      .option('-f, --from <from>', 'specify the transaction sender address for --push')
       .action(function (contractNames, options) {
         if(options.all) addAllImplementations({})
         else {

--- a/src/commands/add-implementation.js
+++ b/src/commands/add-implementation.js
@@ -5,7 +5,7 @@ import addImplementation from '../scripts/add-implementation'
 import addAllImplementations from '../scripts/add-all-implementations'
 
 const signature = 'add [contractNames...]'
-const description = 'add contract implementations to your project. Provide a list of contract names'
+const description = 'add contract implementations to your project. Provide a list of whitespace-separated contract names'
 module.exports = {
   signature, description,
   register: function(program) {

--- a/src/commands/add-implementation.js
+++ b/src/commands/add-implementation.js
@@ -4,26 +4,28 @@ import push from './push'
 import addImplementation from '../scripts/add-implementation'
 import addAllImplementations from '../scripts/add-all-implementations'
 
-module.exports = function(program) {
-  program
-    .command('add [contractNames...]', {noHelp: true})
-    .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
-    .description(`Add contract implementations to your project.
-      Provide a list of [contractNames...] to be registered.
-      Provide an alias to register your contract using the notation <contractName:contractAlias>.
-      If no alias is provided, <contractName> will be used by default.`)
-    .option('--all', 'Skip contract names option and set --all to add all the contracts of your build directory.')
-    .option('--push <network>', 'Push your changes to the specified network')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
-    .action(function (contractNames, options) {
-      if(options.all) addAllImplementations({})
-      else {
-        const contractsData = contractNames.map(rawData => {
-          let [ name, alias ] = rawData.split(':')
-          return { name, alias: (alias || name) }
-        })
-        addImplementation({ contractsData })
-      }
-      if(options.push) push.action({ network: options.push, from: options.from })
-    })
+module.exports = {
+  setup: function(program) {
+    program
+      .command('add [contractNames...]', {noHelp: true})
+      .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
+      .description(`Add contract implementations to your project.
+        Provide a list of [contractNames...] to be registered.
+        Provide an alias to register your contract using the notation <contractName:contractAlias>.
+        If no alias is provided, <contractName> will be used by default.`)
+      .option('--all', 'Skip contract names option and set --all to add all the contracts of your build directory.')
+      .option('--push <network>', 'Push your changes to the specified network')
+      .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
+      .action(function (contractNames, options) {
+        if(options.all) addAllImplementations({})
+        else {
+          const contractsData = contractNames.map(rawData => {
+            let [ name, alias ] = rawData.split(':')
+            return { name, alias: (alias || name) }
+          })
+          addImplementation({ contractsData })
+        }
+        if(options.push) push.action({ network: options.push, from: options.from })
+      })
+  }
 }

--- a/src/commands/add-implementation.js
+++ b/src/commands/add-implementation.js
@@ -1,10 +1,12 @@
+'use strict';
+
 import push from './push'
 import addImplementation from '../scripts/add-implementation'
 import addAllImplementations from '../scripts/add-all-implementations'
 
 module.exports = function(program) {
   program
-    .command('add [contractNames...]')
+    .command('add [contractNames...]', {noHelp: true})
     .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
     .description(`Add contract implementations to your project.
       Provide a list of [contractNames...] to be registered.

--- a/src/commands/bump-version.js
+++ b/src/commands/bump-version.js
@@ -7,7 +7,7 @@ const signature = 'bump <version>'
 const description = 'bump your project to a new <version>'
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('<version> [options]')

--- a/src/commands/bump-version.js
+++ b/src/commands/bump-version.js
@@ -1,17 +1,19 @@
+'use strict';
+
 import push from './push'
 import bumpVersion from '../scripts/bump-version'
 
 module.exports = function(program) {
   program
-    .command('bump <version>')
+    .command('bump <version>', {noHelp: true})
     .usage('<version> [options]')
-    .description("Bump a new <version> of your project with zeppelin_os.")
-    .option('--stdlib <stdlib>', 'Standard library to use')
-    .option('--no-install', 'Skip installing stdlib npm dependencies')
+    .description('Bump your project to a new <version>.')
+    .option('--link <stdlib>', 'Link to new standard library version')
+    .option('--no-install', 'Skip installing stdlib dependencies')
     .option('--push <network>', 'Push your changes to the specified network')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
+    .option('-f, --from <from>', 'Specify the transaction sender address for --push')
     .action(async function (version, options) {
-      const { stdlib: stdlibNameVersion, install: installDeps } = options
+      const { link: stdlibNameVersion, install: installDeps } = options
       await bumpVersion({ version, stdlibNameVersion, installDeps })
       if(options.push) push.action({ network: options.push, from: options.from })
     })

--- a/src/commands/bump-version.js
+++ b/src/commands/bump-version.js
@@ -3,18 +3,20 @@
 import push from './push'
 import bumpVersion from '../scripts/bump-version'
 
-module.exports = function(program) {
-  program
-    .command('bump <version>', {noHelp: true})
-    .usage('<version> [options]')
-    .description('Bump your project to a new <version>.')
-    .option('--link <stdlib>', 'Link to new standard library version')
-    .option('--no-install', 'Skip installing stdlib dependencies')
-    .option('--push <network>', 'Push your changes to the specified network')
-    .option('-f, --from <from>', 'Specify the transaction sender address for --push')
-    .action(async function (version, options) {
-      const { link: stdlibNameVersion, install: installDeps } = options
-      await bumpVersion({ version, stdlibNameVersion, installDeps })
-      if(options.push) push.action({ network: options.push, from: options.from })
-    })
+module.exports = {
+  setup: function(program) {
+    program
+      .command('bump <version>', {noHelp: true})
+      .usage('<version> [options]')
+      .description('Bump your project to a new <version>.')
+      .option('--link <stdlib>', 'Link to new standard library version')
+      .option('--no-install', 'Skip installing stdlib dependencies')
+      .option('--push <network>', 'Push your changes to the specified network')
+      .option('-f, --from <from>', 'Specify the transaction sender address for --push')
+      .action(async function (version, options) {
+        const { link: stdlibNameVersion, install: installDeps } = options
+        await bumpVersion({ version, stdlibNameVersion, installDeps })
+        if(options.push) push.action({ network: options.push, from: options.from })
+      })
+  }
 }

--- a/src/commands/bump-version.js
+++ b/src/commands/bump-version.js
@@ -13,7 +13,7 @@ module.exports = {
       .usage('<version> [options]')
       .description(description)
       .option('--link <stdlib>', 'link to new standard library version')
-      .option('--no-install', 'skip installing stdlib dependencies')
+      .option('--no-install', 'skip installing stdlib dependencies locally')
       .option('--push <network>', 'push changes to the specified network after bumping version')
       .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (version, options) {

--- a/src/commands/bump-version.js
+++ b/src/commands/bump-version.js
@@ -3,16 +3,19 @@
 import push from './push'
 import bumpVersion from '../scripts/bump-version'
 
+const signature = 'bump <version>'
+const description = 'bump your project to a new <version>'
 module.exports = {
+  signature, description,
   setup: function(program) {
     program
-      .command('bump <version>', {noHelp: true})
+      .command(signature, {noHelp: true})
       .usage('<version> [options]')
-      .description('Bump your project to a new <version>.')
-      .option('--link <stdlib>', 'Link to new standard library version')
-      .option('--no-install', 'Skip installing stdlib dependencies')
-      .option('--push <network>', 'Push your changes to the specified network')
-      .option('-f, --from <from>', 'Specify the transaction sender address for --push')
+      .description(description)
+      .option('--link <stdlib>', 'link to new standard library version')
+      .option('--no-install', 'skip installing stdlib dependencies')
+      .option('--push <network>', 'push changes to the specified network after bumping version')
+      .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (version, options) {
         const { link: stdlibNameVersion, install: installDeps } = options
         await bumpVersion({ version, stdlibNameVersion, installDeps })

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -14,7 +14,7 @@ module.exports = {
       .command(signature, {noHelp: true})
       .usage('<alias> --network <network> [options]')
       .description(description)
-      .option('--init [function]', `call function after creating contract. If no name is given, 'initialize' will be used`)
+      .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
       .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
       .option('-f, --from <from>', 'specify transaction sender address')
       .option('-n, --network <network>', 'network to be used')

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -4,33 +4,31 @@ import createProxy from '../scripts/create-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
-module.exports = function(program) {
-  program
-    .command('create <alias>', {noHelp: true})
-    .usage('<alias> --network <network> [options]')
-    .description(`Creates a new proxy for the specified implementation.
-      Provide the <alias> name you used to register your contract.`)
-    .option('--init [function]', 'Call initialization function after creating contract. If no name is given, \'initialize\' will be used')
-    .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
-    .option('-f, --from <from>', 'Set the transactions sender')
-    .option('-n, --network <network>', 'Provide a network to be used')
-    .option('--force', 'Force creation of the proxy even if contracts have local modifications')
-    .action(function (contractAlias, options) {
-      let initMethod = options.init
-      if(typeof initMethod === 'boolean') initMethod = 'initialize'
+module.exports = {
+  setup: function(program) {
+    program
+      .command('create <alias>', {noHelp: true})
+      .usage('<alias> --network <network> [options]')
+      .description(`Creates a new proxy for the specified implementation.
+        Provide the <alias> name you used to register your contract.`)
+      .option('--init [function]', 'Call initialization function after creating contract. If no name is given, \'initialize\' will be used')
+      .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
+      .option('-f, --from <from>', 'Set the transactions sender')
+      .option('-n, --network <network>', 'Provide a network to be used')
+      .option('--force', 'Force creation of the proxy even if contracts have local modifications')
+      .action(function (contractAlias, options) {
+        let initMethod = options.init
+        if(typeof initMethod === 'boolean') initMethod = 'initialize'
 
       let initArgs = options.args
-<<<<<<< 72e1f087365df8ec8ce0c6f35dbe560373f63960
       if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
-=======
-      if(typeof initArgs === 'string') initArgs = initArgs.split(',')
->>>>>>> improve documentation for init
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
-      const { from, network, force } = options
-      const txParams = from ? { from } : {}
-      runWithTruffle(async () => await createProxy({
-        contractAlias, initMethod, initArgs, network, txParams, force
-      }), network)
-    })
+        const { from, network, force } = options
+        const txParams = from ? { from } : {}
+        runWithTruffle(async () => await createProxy({
+          contractAlias, initMethod, initArgs, network, txParams, force
+        }), network)
+      })
+  }
 }

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -1,14 +1,16 @@
+'use strict';
+
 import createProxy from '../scripts/create-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
 module.exports = function(program) {
   program
-    .command('create <alias>')
+    .command('create <alias>', {noHelp: true})
     .usage('<alias> --network <network> [options]')
     .description(`Creates a new proxy for the specified implementation.
       Provide the <alias> name you used to register your contract.`)
-    .option('--init [function]', "Tell whether your contract has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
+    .option('--init [function]', 'Call initialization function after creating contract. If no name is given, \'initialize\' will be used')
     .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
     .option('-f, --from <from>', 'Set the transactions sender')
     .option('-n, --network <network>', 'Provide a network to be used')
@@ -18,11 +20,17 @@ module.exports = function(program) {
       if(typeof initMethod === 'boolean') initMethod = 'initialize'
 
       let initArgs = options.args
+<<<<<<< 72e1f087365df8ec8ce0c6f35dbe560373f63960
       if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
+=======
+      if(typeof initArgs === 'string') initArgs = initArgs.split(',')
+>>>>>>> improve documentation for init
       else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
       const { from, network, force } = options
       const txParams = from ? { from } : {}
-      runWithTruffle(async () => await createProxy({ contractAlias, initMethod, initArgs, network, txParams, force }), network)
+      runWithTruffle(async () => await createProxy({
+        contractAlias, initMethod, initArgs, network, txParams, force
+      }), network)
     })
 }

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -14,7 +14,7 @@ module.exports = {
       .command(signature, {noHelp: true})
       .usage('<alias> --network <network> [options]')
       .description(description)
-      .option('--init [function]', `call initialization function after creating contract. If no name is given, 'initialize' will be used`)
+      .option('--init [function]', `call function after creating contract. If no name is given, 'initialize' will be used`)
       .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
       .option('-f, --from <from>', 'specify transaction sender address')
       .option('-n, --network <network>', 'network to be used')

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -9,7 +9,7 @@ const description = 'deploys a new upgradeable contract instance. Provide the <a
 
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('<alias> --network <network> [options]')

--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -4,18 +4,21 @@ import createProxy from '../scripts/create-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
+const signature = 'create <alias>'
+const description = 'deploys a new upgradeable contract instance. Provide the <alias> you added your contract with'
+
 module.exports = {
+  signature, description,
   setup: function(program) {
     program
-      .command('create <alias>', {noHelp: true})
+      .command(signature, {noHelp: true})
       .usage('<alias> --network <network> [options]')
-      .description(`Creates a new proxy for the specified implementation.
-        Provide the <alias> name you used to register your contract.`)
-      .option('--init [function]', 'Call initialization function after creating contract. If no name is given, \'initialize\' will be used')
-      .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
-      .option('-f, --from <from>', 'Set the transactions sender')
-      .option('-n, --network <network>', 'Provide a network to be used')
-      .option('--force', 'Force creation of the proxy even if contracts have local modifications')
+      .description(description)
+      .option('--init [function]', `call initialization function after creating contract. If no name is given, 'initialize' will be used`)
+      .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
+      .option('-f, --from <from>', 'specify transaction sender address')
+      .option('-n, --network <network>', 'network to be used')
+      .option('--force', 'force creation even if contracts have local modifications')
       .action(function (contractAlias, options) {
         let initMethod = options.init
         if(typeof initMethod === 'boolean') initMethod = 'initialize'

--- a/src/commands/freeze.js
+++ b/src/commands/freeze.js
@@ -10,7 +10,7 @@ module.exports = {
   signature, description,
   setup: function(program) {
     program
-      .command(signature)
+      .command(signature, {noHelp: true})
       .usage('--network <network> [options]')
       .description(description)
       .option('-f, --from <from>', 'specify transaction sender address')

--- a/src/commands/freeze.js
+++ b/src/commands/freeze.js
@@ -8,7 +8,7 @@ const description = 'freeze current release version of your stdlib project'
 
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('--network <network> [options]')

--- a/src/commands/freeze.js
+++ b/src/commands/freeze.js
@@ -1,16 +1,24 @@
+'use strict'
+
 import freeze from '../scripts/freeze'
 import runWithTruffle from '../utils/runWithTruffle'
 
-module.exports = function(program) {
-  program
-    .command('freeze')
-    .usage('--network <network> [options]')
-    .description('Freeze current release version of your stdlib project.')
-    .option('-f, --from <from>', 'Set the transactions sender')
-    .option('-n, --network <network>', 'Provide a network to be used')
-    .action(function (options) {
-      const { from, network } = options
-      const txParams = from ? { from } : {}
-      runWithTruffle(async () => await freeze({ network, txParams }), network)
-    })
+const signature = 'freeze'
+const description = 'freeze current release version of your stdlib project'
+
+module.exports = {
+  signature, description,
+  setup: function(program) {
+    program
+      .command(signature)
+      .usage('--network <network> [options]')
+      .description(description)
+      .option('-f, --from <from>', 'specify transaction sender address')
+      .option('-n, --network <network>', 'network to be used')
+      .action(function (options) {
+        const { from, network } = options
+        const txParams = from ? { from } : {}
+        runWithTruffle(async () => await freeze({ network, txParams }), network)
+      })
+  }
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -14,10 +14,10 @@ module.exports = {
       .command(signature, {noHelp: true})
       .usage('<project> [version]')
       .description(description)
-      .option('--lib', 'create a standard library instead of a regular application')
+      .option('--lib', 'create a standard library instead of an application')
       .option('--force', 'Overwrite existing project if there is one')
-      .option('--link <stdlib>', 'link to standard library')
-      .option('--no-install', 'skip installing stdlib dependencies') 
+      .option('--link <stdlib>', 'link to a standard library')
+      .option('--no-install', 'skip installing standard library') 
       .option('--push <network>', 'push changes to the specified network')
       .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (name, version, options) {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -14,12 +14,12 @@ module.exports = {
       .command(signature, {noHelp: true})
       .usage('<project> [version]')
       .description(description)
-      .option('--lib', 'Create a standard library instead of a regular application')
+      .option('--lib', 'create a standard library instead of a regular application')
       .option('--force', 'Overwrite existing project if there is one')
-      .option('--link <stdlib>', 'Link to standard library')
-      .option('--no-install', 'Skip installing stdlib dependencies') 
-      .option('--push <network>', 'Push changes to the specified network')
-      .option('-f, --from <from>', 'Specify transaction sender address for --push')
+      .option('--link <stdlib>', 'link to standard library')
+      .option('--no-install', 'skip installing stdlib dependencies') 
+      .option('--push <network>', 'push changes to the specified network')
+      .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (name, version, options) {
         if (options.lib) {
           if (options.stdlib)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -9,7 +9,7 @@ const description = `initialize your ZeppelinOS project. Provide a <project> nam
 
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('<project> [version]')

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,7 +17,7 @@ module.exports = {
       .option('--lib', 'create a standard library instead of an application')
       .option('--force', 'Overwrite existing project if there is one')
       .option('--link <stdlib>', 'link to a standard library')
-      .option('--no-install', 'skip installing standard library') 
+      .option('--no-install', 'skip installing stdlib dependencies locally')
       .option('--push <network>', 'push changes to the specified network')
       .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (name, version, options) {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -15,7 +15,7 @@ module.exports = {
       .usage('<project> [version]')
       .description(description)
       .option('--lib', 'create a standard library instead of an application')
-      .option('--force', 'Overwrite existing project if there is one')
+      .option('--force', 'overwrite existing project if there is one')
       .option('--link <stdlib>', 'link to a standard library')
       .option('--no-install', 'skip installing stdlib dependencies locally')
       .option('--push <network>', 'push changes to the specified network')

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,31 +1,38 @@
+'use strict';
+
 import push from './push'
 import init from '../scripts/init'
 import initLib from '../scripts/init-lib'
 
-module.exports = function(program) {
-  program
-    .command('init <project> [version]')
-    .usage('<project> [version] [options]')
-    .description(`Initialize your project with zeppelin_os.
-      Provide a <project> name.
-      Provide a [version] number, otherwise 0.0.1 will be used by default.`)
-    .option('--lib', 'Create a standard library instead of a regular application')
-    .option('--force', 'Override existing project if there is an existing one')
-    .option('--stdlib <stdlib>', 'Standard library to use')
-    .option('--no-install', 'Skip installing stdlib npm dependencies')
-    .option('--push <network>', 'Push your changes to the specified network')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
-    .action(async function (name, version, options) {
-      if (options.lib) {
-        if (options.stdlib) throw Error("Cannot set a stdlib in a library project")
-        await initLib({ name, version })
-      } else {
-        const { force, stdlib: stdlibNameVersion, install: installDeps } = options
-        await init({ name, version, stdlibNameVersion, installDeps, force })
-      }
-      
-      if (options.push) {
-        push.action({ network: options.push, from: options.from })
-      }
-    })
+const signature = 'init <project> [version]'
+const description = `initialize your ZeppelinOS project. Provide a <project> name and optionally a [version] number`
+
+module.exports = {
+  signature, description,
+  setup: function(program) {
+    program
+      .command(signature, {noHelp: true})
+      .usage('<project> [version]')
+      .description(description)
+      .option('--lib', 'Create a standard library instead of a regular application')
+      .option('--force', 'Overwrite existing project if there is one')
+      .option('--link <stdlib>', 'Link to standard library')
+      .option('--no-install', 'Skip installing stdlib dependencies') 
+      .option('--push <network>', 'Push changes to the specified network')
+      .option('-f, --from <from>', 'Specify transaction sender address for --push')
+      .action(async function (name, version, options) {
+        if (options.lib) {
+          if (options.stdlib)
+            throw Error('Cannot set a stdlib in a library project')
+          await initLib({ name, version })
+        } else {
+          const { stdlib: stdlibNameVersion, install: installDeps } = options
+          await init({ name, version, stdlibNameVersion, installDeps })
+        }
+        
+        if (options.push) {
+          push.action({ network: options.push, from: options.from })
+        }
+      })
+  }
 }

--- a/src/commands/link-stdlib.js
+++ b/src/commands/link-stdlib.js
@@ -7,7 +7,7 @@ const signature = 'link <stdlib>'
 const description = 'links project with a standard library located in the <stdlib> npm package'
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('<stdlib> [options]')

--- a/src/commands/link-stdlib.js
+++ b/src/commands/link-stdlib.js
@@ -3,15 +3,18 @@
 import push from './push'
 import linkStdlib from '../scripts/link-stdlib'
 
+const signature = 'link <stdlib>'
+const description = 'links project with a standard library located in the <stdlib> npm package'
 module.exports = {
+  signature, description,
   setup: function(program) {
     program
-      .command('link <stdlib>', {noHelp: true})
+      .command(signature, {noHelp: true})
       .usage('<stdlib> [options]')
-      .description('Links project with a standard library.\n  <stdlib> is the npm package name of the standard library.')
-      .option('--no-install', 'Skip installing stdlib npm dependencies')
-      .option('--push <network>', 'Push your changes to the specified network')
-      .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
+      .description(description)
+      .option('--no-install', 'skip installing stdlib dependencies locally')
+      .option('--push <network>', 'push changes to the specified network')
+      .option('-f, --from <from>', 'specify transaction sender address for --push')
       .action(async function (stdlibNameVersion, options) {
         const installDeps = options.install
         await linkStdlib({ stdlibNameVersion, installDeps })

--- a/src/commands/link-stdlib.js
+++ b/src/commands/link-stdlib.js
@@ -1,11 +1,13 @@
+'use strict';
+
 import push from './push'
 import linkStdlib from '../scripts/link-stdlib'
 
 module.exports = function(program) {
   program
-    .command('link <stdlib>')
+    .command('link <stdlib>', {noHelp: true})
     .usage('<stdlib> [options]')
-    .description("Links a standard library for your project.\n  Provide the npm package of the standard library under <stdlib>.")
+    .description('Links project with a standard library.\n  <stdlib> is the npm package name of the standard library.')
     .option('--no-install', 'Skip installing stdlib npm dependencies')
     .option('--push <network>', 'Push your changes to the specified network')
     .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')

--- a/src/commands/link-stdlib.js
+++ b/src/commands/link-stdlib.js
@@ -3,17 +3,19 @@
 import push from './push'
 import linkStdlib from '../scripts/link-stdlib'
 
-module.exports = function(program) {
-  program
-    .command('link <stdlib>', {noHelp: true})
-    .usage('<stdlib> [options]')
-    .description('Links project with a standard library.\n  <stdlib> is the npm package name of the standard library.')
-    .option('--no-install', 'Skip installing stdlib npm dependencies')
-    .option('--push <network>', 'Push your changes to the specified network')
-    .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
-    .action(async function (stdlibNameVersion, options) {
-      const installDeps = options.install
-      await linkStdlib({ stdlibNameVersion, installDeps })
-      if(options.push) push.action({ network: options.push, from: options.from })
-    })
+module.exports = {
+  setup: function(program) {
+    program
+      .command('link <stdlib>', {noHelp: true})
+      .usage('<stdlib> [options]')
+      .description('Links project with a standard library.\n  <stdlib> is the npm package name of the standard library.')
+      .option('--no-install', 'Skip installing stdlib npm dependencies')
+      .option('--push <network>', 'Push your changes to the specified network')
+      .option('-f, --from <from>', 'Set the transactions sender in case you run with --push')
+      .action(async function (stdlibNameVersion, options) {
+        const installDeps = options.install
+        await linkStdlib({ stdlibNameVersion, installDeps })
+        if(options.push) push.action({ network: options.push, from: options.from })
+      })
+  }
 }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -24,4 +24,4 @@ function action(options) {
   runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, ! skipCompile)
 }
 
-module.exports = { signature, description, setup: registerPush, action}
+module.exports = { signature, description, register: registerPush, action}

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -22,5 +22,5 @@ function action(options) {
   runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, ! skipCompile)
 }
 
-module.exports = registerPush
+module.exports.setup = registerPush
 module.exports.action = action

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -12,7 +12,7 @@ function registerPush(program) {
     .usage('--network <network> [options]')
     .option('-f, --from <from>', 'specify transaction sender address')
     .option('-n, --network <network>', 'network to be used')
-    .option('-s, --skip-compile', 'skips contract compilation')
+    .option('-c, --skip-compile', 'skips contract compilation')
     .option('-d, --deploy-stdlib', 'deploys a copy of the stdlib for development')
     .option('-r, --reset', 'redeploys all contract implementations (not only the ones that changed)')
     .action(action)

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -3,16 +3,18 @@
 import push from '../scripts/push'
 import runWithTruffle from '../utils/runWithTruffle'
 
+const signature = 'push'
+const description = 'deploys your project to the specified <network>'
 function registerPush(program) {
   program
-    .command('push', {noHelp: true})
-    .description('Pushes your project to the specified network')
+    .command(signature, {noHelp: true})
+    .description(description)
     .usage('--network <network> [options]')
-    .option('-f, --from <from>', 'Set the transaction sender address')
-    .option('-n, --network <network>', 'Provide a network to be used')
-    .option('--skip-compile', 'Skips contract compilation')
-    .option('--deploy-stdlib', 'Deploys a copy of the stdlib (if any) instead of using the one published to the network (useful in local development networks)')
-    .option('--reupload', 'Reuploads all contracts')
+    .option('-f, --from <from>', 'specify transaction sender address')
+    .option('-n, --network <network>', 'network to be used')
+    .option('-s, --skip-compile', 'skips contract compilation')
+    .option('-d, --deploy-stdlib', 'deploys a copy of the stdlib for development')
+    .option('-r, --reset', 'redeploys all contract implementations (not only the ones that changed)')
     .action(action)
 }
 
@@ -22,5 +24,4 @@ function action(options) {
   runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, ! skipCompile)
 }
 
-module.exports.setup = registerPush
-module.exports.action = action
+module.exports = { signature, description, setup: registerPush, action}

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -12,9 +12,9 @@ function registerPush(program) {
     .usage('--network <network> [options]')
     .option('-f, --from <from>', 'specify transaction sender address')
     .option('-n, --network <network>', 'network to be used')
-    .option('-c, --skip-compile', 'skips contract compilation')
+    .option('--skip-compile', 'skips contract compilation')
     .option('-d, --deploy-stdlib', 'deploys a copy of the stdlib for development')
-    .option('-r, --reset', 'redeploys all contract implementations (not only the ones that changed)')
+    .option('--reset', 'redeploys all contract implementations (not only the ones that changed)')
     .action(action)
 }
 

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -1,16 +1,18 @@
+'use strict';
+
 import push from '../scripts/push'
 import runWithTruffle from '../utils/runWithTruffle'
 
 function registerPush(program) {
   program
-    .command('push')
+    .command('push', {noHelp: true})
     .description('Pushes your project to the specified network')
     .usage('--network <network> [options]')
-    .option('-f, --from <from>', 'Set the transactions sender')
+    .option('-f, --from <from>', 'Set the transaction sender address')
     .option('-n, --network <network>', 'Provide a network to be used')
     .option('--skip-compile', 'Skips contract compilation')
-    .option('--deploy-stdlib', 'Deploys a copy of the stdlib (if any) instead of using the one already published to the network by its author (useful in local testrpc networks)')
-    .option('--reupload', 'Reuploads all contracts, regardless of not having been modified')
+    .option('--deploy-stdlib', 'Deploys a copy of the stdlib (if any) instead of using the one published to the network (useful in local development networks)')
+    .option('--reupload', 'Reuploads all contracts')
     .action(action)
 }
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,8 @@
 import status from '../scripts/status'
 import runWithTruffle from '../utils/runWithTruffle'
 
-module.exports = function(program) {
+module.exports = {
+  setup: function(program) {
   program
     .command('status', {noHelp: true})
     .description('Print status information on the deployment of your app in the chosen network')
@@ -13,4 +14,5 @@ module.exports = function(program) {
       const { network } = options
       runWithTruffle(async () => await status({ network }), network)
     })
+  }
 }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,10 +1,12 @@
+'use strict';
+
 import status from '../scripts/status'
 import runWithTruffle from '../utils/runWithTruffle'
 
 module.exports = function(program) {
   program
-    .command('status')
-    .description("Print status information on the deployment of your app in the chosen network")
+    .command('status', {noHelp: true})
+    .description('Print status information on the deployment of your app in the chosen network')
     .usage('--network <network>')
     .option('-n, --network <network>', 'Provide a network to be used')
     .action(function (options) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,16 +3,20 @@
 import status from '../scripts/status'
 import runWithTruffle from '../utils/runWithTruffle'
 
+const signature = 'status'
+const description = 'print information about the deployment of your app in a specific network'
+
 module.exports = {
+  signature, description,
   setup: function(program) {
-  program
-    .command('status', {noHelp: true})
-    .description('Print status information on the deployment of your app in the chosen network')
-    .usage('--network <network>')
-    .option('-n, --network <network>', 'Provide a network to be used')
-    .action(function (options) {
-      const { network } = options
-      runWithTruffle(async () => await status({ network }), network)
-    })
+    program
+      .command(signature, {noHelp: true})
+      .description(description)
+      .usage('--network <network>')
+      .option('-n, --network <network>', 'network to be used')
+      .action(function (options) {
+        const { network } = options
+        runWithTruffle(async () => await status({ network }), network)
+      })
   }
 }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -8,7 +8,7 @@ const description = 'print information about the deployment of your app in a spe
 
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .description(description)

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -9,7 +9,7 @@ const description = 'upgrade contract to a new implementation. Provide the <alia
 
 module.exports = {
   signature, description,
-  setup: function(program) {
+  register: function(program) {
     program
       .command(signature, {noHelp: true})
       .usage('[alias] [address] --network <network> [options]')

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -5,7 +5,7 @@ import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
 const signature = 'upgrade [alias] [address]'
-const description = 'upgrade contract to a new implementation. Provide the <alias> you added your contract with. If no [address] is provided, all instances of that contract class will be upgraded'
+const description = 'upgrade contract to a new implementation. Provide the [alias] you added your contract with, or use --all flag to upgrade all. If no [address] is provided, all instances of that contract class will be upgraded'
 
 module.exports = {
   signature, description,

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -5,7 +5,7 @@ import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
 const signature = 'upgrade [alias] [address]'
-const description = 'upgrade contract to a new implementation. Provide the <alias> you added your contract with. If no [address] is provided, all instances of that contract class will be upgraded.'
+const description = 'upgrade contract to a new implementation. Provide the <alias> you added your contract with. If no [address] is provided, all instances of that contract class will be upgraded'
 
 module.exports = {
   signature, description,

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -4,31 +4,33 @@ import upgradeProxy from '../scripts/upgrade-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
-module.exports = function(program) {
-  program
-    .command('upgrade [alias] [address]', {noHelp: true})
-    .usage('[alias] [address] --network <network> [options]')
-    .description(`Upgrade a proxied contract to a new implementation.
-      Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
-    .option('--init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
-    .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
-    .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
-    .option('-f, --from <from>', 'Set the transactions sender')
-    .option('-n, --network <network>', 'Provide a network to be used')
-    .option('--force', 'Force upgrading the proxy even if contracts have local modifications')
-    .action(function (contractAlias, proxyAddress, options) {
-      let initMethod = options.init
-      if(typeof initMethod === 'boolean') initMethod = 'initialize'
+module.exports = {
+  setup: function(program) {
+    program
+      .command('upgrade [alias] [address]', {noHelp: true})
+      .usage('[alias] [address] --network <network> [options]')
+      .description(`Upgrade a proxied contract to a new implementation.
+        Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
+      .option('--init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
+      .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
+      .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
+      .option('-f, --from <from>', 'Set the transactions sender')
+      .option('-n, --network <network>', 'Provide a network to be used')
+      .option('--force', 'Force upgrading the proxy even if contracts have local modifications')
+      .action(function (contractAlias, proxyAddress, options) {
+        let initMethod = options.init
+        if(typeof initMethod === 'boolean') initMethod = 'initialize'
 
-      let initArgs = options.args
-      if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
-      else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
+        let initArgs = options.args
+        if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
+        else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
 
-      const { from, network, all, force } = options
-      const txParams = from ? { from } : {}
-      runWithTruffle(async () => await upgradeProxy({
-        contractAlias, proxyAddress, initMethod, initArgs,
-        all, network, txParams, force
-      }), network)
-    })
+        const { from, network, all, force } = options
+        const txParams = from ? { from } : {}
+        runWithTruffle(async () => await upgradeProxy({
+          contractAlias, proxyAddress, initMethod, initArgs,
+          all, network, txParams, force
+        }), network)
+      })
+  }
 }

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -4,19 +4,22 @@ import upgradeProxy from '../scripts/upgrade-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
+const signature = 'upgrade [alias] [address]'
+const description = 'upgrade contract to a new implementation. Provide the <alias> you added your contract with. If no [address] is provided, all instances of that contract class will be upgraded.'
+
 module.exports = {
+  signature, description,
   setup: function(program) {
     program
-      .command('upgrade [alias] [address]', {noHelp: true})
+      .command(signature, {noHelp: true})
       .usage('[alias] [address] --network <network> [options]')
-      .description(`Upgrade a proxied contract to a new implementation.
-        Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
-      .option('--init [function]', "Tell whether your new implementation has to be initialized or not. You can provide name of the initialization function. If none is given, 'initialize' will be considered by default")
-      .option('--args <arg1, arg2, ...>', 'Provide initialization arguments for your contract if required')
-      .option('--all', 'Skip the alias option and set --all to upgrade all proxies in the application')
-      .option('-f, --from <from>', 'Set the transactions sender')
-      .option('-n, --network <network>', 'Provide a network to be used')
-      .option('--force', 'Force upgrading the proxy even if contracts have local modifications')
+      .description(description)
+      .option('--init [function]', `call function after upgrading contract. If no name is given, 'initialize' will be used`)
+      .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
+      .option('--all', 'upgrade all contracts in the application')
+      .option('-f, --from <from>', 'specify transaction sender address')
+      .option('-n, --network <network>', 'network to be used')
+      .option('--force', 'force creation even if contracts have local modifications')
       .action(function (contractAlias, proxyAddress, options) {
         let initMethod = options.init
         if(typeof initMethod === 'boolean') initMethod = 'initialize'

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -1,10 +1,12 @@
+'use strict';
+
 import upgradeProxy from '../scripts/upgrade-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseArgs } from '../utils/input'
 
 module.exports = function(program) {
   program
-    .command('upgrade [alias] [address]')
+    .command('upgrade [alias] [address]', {noHelp: true})
     .usage('[alias] [address] --network <network> [options]')
     .description(`Upgrade a proxied contract to a new implementation.
       Provide the [alias] name you used to register your contract. Provide [address] to choose which proxy to upgrade, otherwise all will be upgraded.`)
@@ -24,6 +26,9 @@ module.exports = function(program) {
 
       const { from, network, all, force } = options
       const txParams = from ? { from } : {}
-      runWithTruffle(async () => await upgradeProxy({ contractAlias, proxyAddress, initMethod, initArgs, all, network, txParams, force }), network)
+      runWithTruffle(async () => await upgradeProxy({
+        contractAlias, proxyAddress, initMethod, initArgs,
+        all, network, txParams, force
+      }), network)
     })
 }

--- a/src/scripts/add-implementation.js
+++ b/src/scripts/add-implementation.js
@@ -1,4 +1,6 @@
-import ControllerFor from "../models/local/ControllerFor";
+'use strict';
+
+import ControllerFor from '../models/local/ControllerFor';
 
 export default function addImplementation({ contractsData, packageFileName = undefined }) {
   if (contractsData.length === 0) throw new Error('At least one contract name must be provided to add a new implementation.')


### PR DESCRIPTION
- rename `--stdlib` option in `bump` command to `--link`. E.g: `zos bump 1.2.0 --link openzeppelin-zos@1.1.0`
- improve help message with differentiated main help with per-command help
- improve all commands and parameters help
- rename `--reupload` option in `push` command to `--reset`.
- make main help prettier

Fixes https://github.com/zeppelinos/zos-cli/issues/141
