### PR TITLE
Log there are no proxies found to upgrade when specifying contract

### DIFF
--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -92,7 +92,7 @@ export default class NetworkAppController extends NetworkBaseController {
 
   async upgradeProxies(contractAlias, proxyAddress, initMethod, initArgs) {
     const proxyInfos = this.getProxies(contractAlias, proxyAddress);
-    if (_.isEmpty(proxyInfos)) {
+    if (_.isEmpty(proxyInfos) || (contractAlias && _.isEmpty(proxyInfos[contractAlias]))) {
       log.info("No proxies to upgrade were found");
       return;
     }


### PR DESCRIPTION
If contract name was set, and no proxies for it were found, then
the app would fail to report that no proxies were upgraded.

Fixes #176 