### PR TITLE
Args flag implies initialization in create and upgrade proxy

### DIFF
--- a/src/commands/create-proxy.js
+++ b/src/commands/create-proxy.js
@@ -2,7 +2,7 @@
 
 import createProxy from '../scripts/create-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
-import { parseArgs } from '../utils/input'
+import { parseInit } from '../utils/input'
 
 const signature = 'create <alias>'
 const description = 'deploys a new upgradeable contract instance. Provide the <alias> you added your contract with'
@@ -20,13 +20,7 @@ module.exports = {
       .option('-n, --network <network>', 'network to be used')
       .option('--force', 'force creation even if contracts have local modifications')
       .action(function (contractAlias, options) {
-        let initMethod = options.init
-        if(typeof initMethod === 'boolean') initMethod = 'initialize'
-
-      let initArgs = options.args
-      if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
-      else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
-
+        const { initMethod, initArgs } = parseInit(options, 'initialize')
         const { from, network, force } = options
         const txParams = from ? { from } : {}
         runWithTruffle(async () => await createProxy({

--- a/src/commands/upgrade-proxy.js
+++ b/src/commands/upgrade-proxy.js
@@ -2,7 +2,7 @@
 
 import upgradeProxy from '../scripts/upgrade-proxy'
 import runWithTruffle from '../utils/runWithTruffle'
-import { parseArgs } from '../utils/input'
+import { parseInit } from '../utils/input'
 
 const signature = 'upgrade [alias] [address]'
 const description = 'upgrade contract to a new implementation. Provide the [alias] you added your contract with, or use --all flag to upgrade all. If no [address] is provided, all instances of that contract class will be upgraded'
@@ -21,13 +21,7 @@ module.exports = {
       .option('-n, --network <network>', 'network to be used')
       .option('--force', 'force creation even if contracts have local modifications')
       .action(function (contractAlias, proxyAddress, options) {
-        let initMethod = options.init
-        if(typeof initMethod === 'boolean') initMethod = 'initialize'
-
-        let initArgs = options.args
-        if(typeof initArgs === 'string') initArgs = parseArgs(initArgs)
-        else if(typeof initArgs === 'boolean' || initMethod) initArgs = []
-
+        const { initMethod, initArgs } = parseInit(options, 'initialize')
         const { from, network, all, force } = options
         const txParams = from ? { from } : {}
         runWithTruffle(async () => await upgradeProxy({

--- a/src/utils/input.js
+++ b/src/utils/input.js
@@ -11,3 +11,15 @@ export function parseArgs(args) {
     throw Error(`Error parsing arguments: ${e}`);
   }
 }
+
+export function parseInit(options, defaultInit) {
+  let initMethod = options.init;
+  if (typeof initMethod === 'boolean') initMethod = defaultInit;
+  if (!initMethod && typeof options.args !== 'undefined') initMethod = defaultInit;
+
+  let initArgs = options.args;
+  if(typeof initArgs === 'string') initArgs = parseArgs(initArgs);
+  else if(typeof initArgs === 'boolean' || initMethod) initArgs = [];
+
+  return { initMethod, initArgs };
+}

--- a/test/utils/input.test.js
+++ b/test/utils/input.test.js
@@ -1,19 +1,34 @@
 'use strict'
 require('../setup');
 
-import { parseArgs } from '../../src/utils/input';
+import { parseArgs, parseInit } from '../../src/utils/input';
 
 describe('input', function () {
-  const testFn = (input, ... expected) => (
-    () => parseArgs(input).should.deep.eq(expected)
-  );
+  describe('parseArgs', function () {
+    const testFn = (input, ... expected) => (
+      () => parseArgs(input).should.deep.eq(expected)
+    );
 
-  it('should parse a number', testFn("42", "42"));
-  it('should parse a quoted string', testFn('"foo"', 'foo'));
-  it('should parse an array', testFn('[1, 2, 3]', ["1", "2", "3"]));
-  it('should parse nested arrays', testFn("[1,[2,3],4]", ["1",["2","3"],"4"]));
-  it('should parse multiple arguments', testFn('42,43,"foo",[1,2,"bar"]', '42', '43', 'foo', ['1', '2', 'bar']));
-  it('should parse an address', testFn("0x1234", "0x1234"));
-  it('should parse a quoted address', testFn('"0x1234"', "0x1234"));
-  it('should parse multiple addresses', testFn('0x1234,0x1235', "0x1234", "0x1235"));
+    it('should parse a number', testFn("42", "42"));
+    it('should parse a quoted string', testFn('"foo"', 'foo'));
+    it('should parse an array', testFn('[1, 2, 3]', ["1", "2", "3"]));
+    it('should parse nested arrays', testFn("[1,[2,3],4]", ["1",["2","3"],"4"]));
+    it('should parse multiple arguments', testFn('42,43,"foo",[1,2,"bar"]', '42', '43', 'foo', ['1', '2', 'bar']));
+    it('should parse an address', testFn("0x1234", "0x1234"));
+    it('should parse a quoted address', testFn('"0x1234"', "0x1234"));
+    it('should parse multiple addresses', testFn('0x1234,0x1235', "0x1234", "0x1235"));
+  });
+
+  describe('parseInit', function () {
+    const defaultInit = 'INITIALIZE';
+    const testFn = (options, expectedInit, expectedArgs) => (
+      () => parseInit(options, defaultInit).should.deep.eq({ initMethod: expectedInit, initArgs: expectedArgs })
+    );
+
+    it('should not init', testFn({}, undefined, undefined));
+    it('should init with default when init is set', testFn({ init: true }, defaultInit, []));
+    it('should init when args is set', testFn({ args: '20' }, defaultInit, ["20"]));
+    it('should init with specific function', testFn({ init: 'foo' }, 'foo', []));
+    it('should init with specific function and args', testFn({ init: 'foo', args: '20' }, 'foo', ['20']));
+  });
 });


### PR DESCRIPTION
When setting --args, if --init is not set, it will still invoke
the initializer with the default init method name. Affects create
and upgrade proxy.

Fixes #182 