### PR TITLE
Build project on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+os:
+- linux
+- osx
 node_js:
 - '8'
 cache:


### PR DESCRIPTION
We have had a few issues with regex incomatible between linux and
mac os, which the CI has failed to catch.