### PR TITLE
tests: setup and cleanup tmp dir

### DIFF
--- a/test/helpers/cleanup.js
+++ b/test/helpers/cleanup.js
@@ -1,11 +1,33 @@
 import fs from 'fs'
+import path from 'path'
 
 export function cleanup(path) {
   try {
     const stat = fs.statSync(path)
-    if(stat.isDirectory()) fs.rmdirSync(path)
+    if(stat.isDirectory()) {
+      rimraf(path)
+    }
     else fs.unlinkSync(path)
   } catch(e) { /* swallow exception */ }
+}
+
+/**
+ * Remove directory recursively
+ * @param {string} dir_path
+ * @see https://stackoverflow.com/a/42505874/3027390
+ */
+function rimraf(dir_path) {
+  if (fs.existsSync(dir_path)) {
+    fs.readdirSync(dir_path).forEach(function(entry) {
+      var entry_path = path.join(dir_path, entry);
+      if (fs.lstatSync(entry_path).isDirectory()) {
+        rimraf(entry_path);
+      } else {
+        fs.unlinkSync(entry_path);
+      }
+    });
+    fs.rmdirSync(dir_path);
+  }
 }
 
 export function cleanupfn(filename) {

--- a/test/models/Truffle.test.js
+++ b/test/models/Truffle.test.js
@@ -12,14 +12,12 @@ contract('Truffle', function () {
   const truffleConfigFile = `${tmpDir}/truffle-config.js`
   const truffleConfigPath = `${process.cwd()}/${truffleConfigFile}`
 
-  afterEach('cleanup files & folders', function () {
-    cleanup(`${contractsDir}/.gitkeep`)
-    cleanup(`${contractsDir}/Sample.sol`)
-    cleanup(contractsDir)
-    cleanup(`${migrationsDir}/01_sample.js`)
-    cleanup(`${migrationsDir}/.gitkeep`)
-    cleanup(migrationsDir)
-    cleanup(truffleConfigFile)
+  beforeEach('cleanup files & folders', function () {
+    fs.createDir(tmpDir)
+  })
+
+  afterEach('', function () {
+    cleanup(tmpDir)
   })
 
   it('should create an empty contracts folder if missing', async function () {

--- a/test/scripts/add-all.test.js
+++ b/test/scripts/add-all.test.js
@@ -8,14 +8,15 @@ import { FileSystem as fs } from 'zos-lib';
 contract('add-all command', function() {
   const appName = 'MyApp'
   const defaultVersion = '0.1.0'
-  const packageFileName = 'test/tmp/zos.json'
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
 
   beforeEach('setup', async function() {
-    cleanup(packageFileName);
+    fs.createDir(tmpDir);
     await init({ name: appName, version: defaultVersion, packageFileName })
   })
 
-  after(cleanupfn(packageFileName))
+  afterEach(cleanupfn(tmpDir))
 
   it('should add all contracts in build contracts dir', function() {
     addAll({ packageFileName })

--- a/test/scripts/add.test.js
+++ b/test/scripts/add.test.js
@@ -9,7 +9,8 @@ import CaptureLogs from '../helpers/captureLogs';
 import add from '../../src/scripts/add.js';
 
 contract('add command', function() {
-  const packageFileName = 'test/tmp/zos.json';
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
   const appName = 'MyApp';
   const contractName = 'ImplV1';
   const contractAlias = 'Impl';
@@ -17,11 +18,11 @@ contract('add command', function() {
   const contractsData = [{ name: contractName, alias: contractAlias }]
 
   beforeEach('setup', async function() {
-    cleanup(packageFileName);
+    fs.createDir(tmpDir);
     await init({ name: appName, version: defaultVersion, packageFileName });
   });
 
-  after(cleanupfn(packageFileName));
+  afterEach(cleanupfn(tmpDir));
 
   it('should add a logic contract an alias and a filename', function() {
     add({ contractsData, packageFileName});

--- a/test/scripts/bump.test.js
+++ b/test/scripts/bump.test.js
@@ -12,15 +12,16 @@ import add from '../../src/scripts/add.js';
 contract('new-version command', function() {
   const appName = 'MyApp';
   const defaultVersion = '0.1.0';
-  const packageFileName = 'test/tmp/zos.json';
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
 
   describe('on app', function () {
     beforeEach('setup', async function() {
-      cleanup(packageFileName)
+      fs.createDir(tmpDir);
       await init({ name: appName, version: defaultVersion, packageFileName });
     });
 
-    after('cleanup', cleanupfn(packageFileName));
+    afterEach('cleanup', cleanupfn(tmpDir));
 
     it('should update the app version in the main package file', async function() {
       const version = '0.2.0';
@@ -65,11 +66,11 @@ contract('new-version command', function() {
 
   describe('on lib', function () {
     beforeEach('setup', async function() {
-      cleanup(packageFileName)
+      fs.createDir(tmpDir);
       await initLib({ name: appName, version: defaultVersion, packageFileName });
     });
 
-    after('cleanup', cleanupfn(packageFileName));
+    afterEach('cleanup', cleanupfn(tmpDir));
 
     it('should update the lib version in the main package file', async function() {
       const version = '0.2.0';

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -30,19 +30,18 @@ contract('create command', function([_, owner]) {
   const appName = 'MyApp';
   const defaultVersion = '0.1.0';
   const network = 'test';
-  const packageFileName = 'test/tmp/zos.json';
-  const networkFileName = `test/tmp/zos.${network}.json`;
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
+  const networkFileName = `${tmpDir}/zos.${network}.json`;
 
   beforeEach('setup', async function() {
-    cleanup(packageFileName)
-    cleanup(networkFileName)
+    fs.createDir(tmpDir);
     await init({ name: appName, version: defaultVersion, packageFileName });
     await add({ contractsData, packageFileName });
     await push({ packageFileName, network, txParams });
   });
 
-  after(cleanupfn(packageFileName))
-  after(cleanupfn(networkFileName))
+  afterEach(cleanupfn(tmpDir))
 
   const assertProxy = async function(proxyInfo, { version, say, implementation }) {
     proxyInfo.address.should.be.nonzeroAddress;
@@ -165,5 +164,5 @@ contract('create command', function([_, owner]) {
       await assertProxy(data.proxies[contractAlias][0], { version: defaultVersion, say: 'V1' });
     });
   });
-  
+
 });

--- a/test/scripts/init-lib.test.js
+++ b/test/scripts/init-lib.test.js
@@ -8,10 +8,11 @@ import { cleanupfn } from "../helpers/cleanup.js";
 contract('init-lib command', function() {
   const appName = "MyLib";
   const appVersion = "0.3.0";
-  const packageFileName = "test/tmp/zos.json";
+  const tmpDir = "test/tmp";
+  const packageFileName = `${tmpDir}/zos.json`;
 
-  beforeEach(cleanupfn(packageFileName))
-  after(cleanupfn(packageFileName))
+  beforeEach(() => fs.createDir(tmpDir))
+  afterEach(cleanupfn(tmpDir))
 
   describe('created file', function() {
     it('should exist', async function() {

--- a/test/scripts/init.test.js
+++ b/test/scripts/init.test.js
@@ -7,11 +7,12 @@ import { cleanupfn } from "../helpers/cleanup.js";
 
 contract('init command', function() {
   const appName = "MyApp";
-  const packageFileName = "test/tmp/zos.json";
+  const tmpDir = "test/tmp";
+  const packageFileName = `${tmpDir}/zos.json`;
   const appVersion = "0.3.0";
 
-  beforeEach(cleanupfn(packageFileName))
-  after(cleanupfn(packageFileName))
+  beforeEach(() => fs.createDir(tmpDir))
+  afterEach(cleanupfn(tmpDir))
 
   describe('created file', function() {
     it('should exist', async function() {

--- a/test/scripts/link.test.js
+++ b/test/scripts/link.test.js
@@ -10,14 +10,15 @@ import linkStdlib from '../../src/scripts/link.js';
 contract('link command', function() {
   const appName = 'MyApp';
   const defaultVersion = '0.1.0';
-  const packageFileName = 'test/tmp/zos.json';
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
 
   beforeEach('setup', async function() {
-    cleanup(packageFileName)
+    fs.createDir(tmpDir);
     await init({ name: appName, version: defaultVersion, packageFileName, stdlib: 'mock-stdlib@1.0.0' });
   });
 
-  after('cleanup', cleanupfn(packageFileName));
+  afterEach('cleanup', cleanupfn(tmpDir));
 
   it('should set stdlib', async function () {
     await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFileName });

--- a/test/scripts/status.test.js
+++ b/test/scripts/status.test.js
@@ -1,6 +1,7 @@
 'use strict'
 require('../setup')
 
+import { FileSystem as fs } from 'zos-lib';
 import initApp from '../../src/scripts/init.js';
 import initLib from '../../src/scripts/init-lib.js';
 import add from '../../src/scripts/add.js';
@@ -20,24 +21,22 @@ contract('status command', function([_, owner]) {
   const network = 'test';
   const contractName = 'ImplV1';
   const contractAlias = 'Impl';
-  const contractsData = [{ name: contractName, alias: contractAlias }]
+  const contractsData = [{ name: contractName, alias: contractAlias }];
   const anotherContractName = 'AnotherImplV1';
   const stdlibNameVersion = 'mock-stdlib@1.1.0';
-  const packageFileName = 'test/tmp/zos.json';
-  const networkFileName = `test/tmp/zos.${network}.json`;
-  
-  beforeEach('cleanup', async function() {
-    cleanup(packageFileName)
-    cleanup(networkFileName)
+  const tmpDir = 'test/tmp';
+  const packageFileName = `${tmpDir}/zos.json`;
+  const networkFileName = `${tmpDir}/zos.${network}.json`;
+
+  beforeEach('setup', async function() {
+    fs.createDir(tmpDir);
     this.logs = new CaptureLogs();
   });
 
-  afterEach(function () {
+  afterEach('cleanup', function () {
+    cleanup(tmpDir);
     this.logs.restore();
   });
-
-  after(cleanupfn(packageFileName));
-  after(cleanupfn(networkFileName));
 
   const shouldDescribeApp = function (init) {
     describe('root app', function () {
@@ -106,7 +105,7 @@ contract('status command', function([_, owner]) {
 
         this.logs.text.should.match(/Impl/i);
         this.logs.text.should.match(/implemented by ImplV1/i);
-      });  
+      });
 
       it('should not log contract name when matches alias', async function () {
         await init({ name: appName, version, packageFileName });
@@ -116,7 +115,7 @@ contract('status command', function([_, owner]) {
 
         this.logs.text.should.match(/AnotherImplV1/i);
         this.logs.text.should.not.match(/implemented by/i);
-      });  
+      });
 
       it('should log undeployed contract', async function () {
         await init({ name: appName, version, packageFileName });
@@ -144,7 +143,7 @@ contract('status command', function([_, owner]) {
         await status({ network, packageFileName, networkFileName });
 
         this.logs.text.should.match(/is deployed and up to date/i);
-      });    
+      });
     });
   };
 
@@ -217,7 +216,7 @@ contract('status command', function([_, owner]) {
         await push({ packageFileName, network, txParams });
         await createProxy({ contractAlias, network, txParams, packageFileName, networkFileName });
         await status({ network, packageFileName, networkFileName });
-        
+
         this.logs.text.should.match(/Impl at 0x[0-9a-fA-F]{40} version 0.1.0/i);
       });
     });


### PR DESCRIPTION
It's a better pattern to set up and tear down the tmp dir on each test.
This change ensures that the dir is always clean, and that tests will not
affect each other.