### PR TITLE
Use zos-lib contracts instead of truffle artifacts for testing

### DIFF
--- a/contracts/Imports.sol
+++ b/contracts/Imports.sol
@@ -1,9 +1,0 @@
-pragma solidity ^0.4.21;
-
-import "zos-lib/contracts/upgradeability/Proxy.sol";
-import "zos-lib/contracts/application/AppDirectory.sol";
-import "zos-lib/contracts/application/PackagedApp.sol";
-import "zos-lib/contracts/application/UnversionedApp.sol";
-import "zos-lib/contracts/application/versioning/Package.sol";
-import "zos-lib/contracts/application/versioning/Release.sol";
-import "zos-lib/contracts/application/versioning/ImplementationDirectory.sol";

--- a/test/models/TestApp.test.js
+++ b/test/models/TestApp.test.js
@@ -1,10 +1,11 @@
 'use strict'
 require('../setup')
 
+import { Contracts } from 'zos-lib'
 import testApp from '../../src/models/TestApp';
 
-const ImplV1 = artifacts.require('ImplV1');
-const ImplV2 = artifacts.require('ImplV2');
+const ImplV1 = Contracts.getFromLocal('ImplV1');
+const ImplV2 = Contracts.getFromLocal('ImplV2');
 
 contract('TestApp', function ([_, owner]) {
   const txParams = { from: owner }

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -1,17 +1,17 @@
 'use strict'
 require('../setup')
 
-import { Logger, FileSystem as fs } from 'zos-lib';
+import CaptureLogs from '../helpers/captureLogs';
 import { cleanup, cleanupfn } from '../helpers/cleanup.js';
+import { Contracts, Logger, FileSystem as fs } from 'zos-lib';
 
+import add from '../../src/scripts/add.js';
 import init from '../../src/scripts/init.js';
 import push from '../../src/scripts/push.js';
 import createProxy from '../../src/scripts/create.js';
 import linkStdlib from '../../src/scripts/link.js';
-import add from '../../src/scripts/add.js';
-import CaptureLogs from '../helpers/captureLogs';
 
-const ImplV1 = artifacts.require('ImplV1');
+const ImplV1 = Contracts.getFromLocal('ImplV1');
 
 contract('create command', function([_, owner]) {
   const contractName = 'ImplV1';

--- a/test/scripts/push.test.js
+++ b/test/scripts/push.test.js
@@ -1,16 +1,17 @@
 'use strict'
 require('../setup')
 
+import { cleanup, cleanupfn } from '../helpers/cleanup'
+import { Contracts, FileSystem as fs, App, Package } from 'zos-lib'
+
 import push from '../../src/scripts/push.js';
 import freeze from '../../src/scripts/freeze';
 import add from '../../src/scripts/add';
-import { FileSystem as fs, App, Package } from 'zos-lib'
-import { cleanup, cleanupfn } from '../helpers/cleanup';
 import bumpVersion from '../../src/scripts/bump';
 
-const ImplV1 = artifacts.require('ImplV1');
-const PackageContract = artifacts.require('Package');
-const ImplementationDirectory = artifacts.require('ImplementationDirectory');
+const ImplV1 = Contracts.getFromLocal('ImplV1');
+const PackageContract = Contracts.getFromNodeModules('zos-lib', 'Package');
+const ImplementationDirectory = Contracts.getFromNodeModules('zos-lib', 'ImplementationDirectory');
 
 contract('push command', function([_, owner]) {
   const network = 'test';


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos-cli/issues/209

We don't need to use truffle artifacts for testing, we can use our `Contracts` objects
After this, we don't need to have the `Imports` contract anymore
