### PR TITLE
Fixed upgrade script name in bin

### DIFF
--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import upgradeProxy from '../scripts/upgrade-proxy'
+import upgradeProxy from '../scripts/upgrade'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseInit } from '../utils/input'
 


### PR DESCRIPTION
The upgrade command was looking for `upgrade-proxy`, now renamed to `upgrade`.