### PR TITLE
Initialize contracts list if missing before adding contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ node_modules
 zos*
 build
 lib
+.DS_Store
+.idea
 .node-xmlhttprequest-sync-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@ node_modules
 zos*
 build
 lib
-.DS_Store
-.idea
 .node-xmlhttprequest-sync-*

--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -45,6 +45,7 @@ export default class LocalBaseController {
       log.error(`Contract ${contractName} has an explicit constructor. Move it to an initializer function to use it with ZeppelinOS.`)
     }
 
+    if (!this.packageData.contracts) this.packageData.contracts = {};
     this.packageData.contracts[contractAlias] = contractName;
   }
 


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos-cli/issues/230

After following the [tutorial](https://docs.zeppelinos.org/docs/setup.html) I managed to stumble upon this issue in 30 mins.

The problem occurred when `stdlib` was set in the `zos.json` file, because the `packageData` object was initialized in `LocalBaseController` with its `contracts` property set to null.