### PR TITLE
Introduce a 'zos session <network>' command.

### DIFF
--- a/src/bin/program.js
+++ b/src/bin/program.js
@@ -15,19 +15,20 @@ const upgrade = require('../commands/upgrade')
 const link = require('../commands/link')
 const status = require('../commands/status')
 const freeze = require('../commands/freeze')
+const session = require('../commands/session')
 
 program
   .name('zos')
   .usage('<command> [options]')
   .description('where <command> is one of:\n' +
-          '\t add, bump, create, init, link, push, status, upgrade.')
+          '\t add, bump, create, init, link, push, status, upgrade, session.')
   .version(version, '--version')
   .option('-v, --verbose', 'verbose mode on: output errors stacktrace and detailed log.')
   .option('-s, --silent', 'silent mode: no output sent to stderr.')
   .on('option:verbose', () => { Logger.verbose(true); } )
   .on('option:silent', () => { Logger.silent(true); } )
 
-const commands = [init, add, push, create, bump, upgrade, link, status, freeze]
+const commands = [init, add, push, create, bump, upgrade, link, status, freeze, session]
 
 commands.forEach((c) => c.register(program));
 

--- a/src/commands/session.js
+++ b/src/commands/session.js
@@ -5,16 +5,16 @@ import { setNetwork as setNetwork } from '../scripts/session';
 const signature = 'session';
 const description = 'by providing --network <network>, commands like create, ' +
                     'freeze, push, status and upgrade will use <network> ' +
-                    'unless overriden. Use --remove to undo.';
+                    'unless overriden. Use --close to undo.';
 
 module.exports = {
   signature, description,
   register: function(program) {
     program
       .command(signature, {noHelp: false})
-      .usage('Either --network <network> or --remove')
+      .usage('Either --network <network> or --close')
       .option('--network <network>')
-      .option('--remove')
+      .option('--close')
       .description(description)
       .action(setNetwork);
   }

--- a/src/commands/session.js
+++ b/src/commands/session.js
@@ -1,24 +1,21 @@
 'use strict';
 
-import { FileSystem as fs } from 'zos-lib'
-import { Logger } from 'zos-lib'
+import { setNetwork as setNetwork } from '../scripts/session';
 
-const signature = 'session <network>'
-const description = 'by providing <network>, commands like create, ' +
+const signature = 'session';
+const description = 'by providing --network <network>, commands like create, ' +
                     'freeze, push, status and upgrade will use <network> ' +
-                    'unless overriden.'
+                    'unless overriden. Use --remove to undo.';
 
 module.exports = {
   signature, description,
   register: function(program) {
     program
-      .command(signature, {noHelp: true})
-      .usage('<network>')
+      .command(signature, {noHelp: false})
+      .usage('Either --network <network> or --remove')
+      .option('--network <network>')
+      .option('--remove')
       .description(description)
-      .action(async function (networkName, options) {
-        fs.write('/tmp/.zos_session', networkName)
-        let log = new Logger('commands/session')
-        log.info('Using "' + networkName + '" as default network unless overriden.')
-      })
+      .action(setNetwork);
   }
 }

--- a/src/commands/session.js
+++ b/src/commands/session.js
@@ -1,0 +1,24 @@
+'use strict';
+
+import { FileSystem as fs } from 'zos-lib'
+import { Logger } from 'zos-lib'
+
+const signature = 'session <network>'
+const description = 'by providing <network>, commands like create, ' +
+                    'freeze, push, status and upgrade will use <network> ' +
+                    'unless overriden.'
+
+module.exports = {
+  signature, description,
+  register: function(program) {
+    program
+      .command(signature, {noHelp: true})
+      .usage('<network>')
+      .description(description)
+      .action(async function (networkName, options) {
+        fs.write('/tmp/.zos_session', networkName)
+        let log = new Logger('commands/session')
+        log.info('Using "' + networkName + '" as default network unless overriden.')
+      })
+  }
+}

--- a/src/scripts/session.js
+++ b/src/scripts/session.js
@@ -1,0 +1,34 @@
+'use strict';
+
+import { FileSystem as fs } from 'zos-lib';
+import { Logger } from 'zos-lib';
+
+const ZOS_SESSION_PATH = '.zos.session';
+
+export function getNetwork() {
+  var networkName = undefined;
+  try {
+    networkName = fs.read(ZOS_SESSION_PATH).toString();
+  } catch(e) {
+  }
+
+  return networkName;
+}
+
+export function setNetwork({ network = undefined, remove = false }) {
+  if ((!network && !remove) || (network && remove)) {
+    throw Error('Please provide either --network <network> or --remove.')
+  }
+
+  let log = new Logger('scripts/session');
+  if (remove) {
+    // no unlink in FileSystem?
+    fs.write(ZOS_SESSION_PATH, '');
+    log.info(`Cleared ${ZOS_SESSION_PATH}.`);
+    return;
+  }
+
+  fs.write(ZOS_SESSION_PATH, network);
+  log.info(`Using "${network}" as default network unless overriden.`);
+}
+

--- a/src/scripts/session.js
+++ b/src/scripts/session.js
@@ -15,14 +15,14 @@ export function getNetwork() {
   return networkName;
 }
 
-export function setNetwork({ network = undefined, remove = false }) {
-  if ((!network && !remove) || (network && remove)) {
-    throw Error('Please provide either --network <network> or --remove.')
+export function setNetwork({ network = undefined, close = false }) {
+  if ((!network && !close) || (network && close)) {
+    throw Error('Please provide either --network <network> or --close.')
   }
 
   let log = new Logger('scripts/session');
 
-  if (remove) {
+  if (close) {
     if (fs.existsSync(ZOS_SESSION_PATH)) {
       fs.unlinkSync(ZOS_SESSION_PATH);
     }

--- a/src/scripts/session.js
+++ b/src/scripts/session.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { FileSystem as fs } from 'zos-lib';
+import fs from 'fs';
 import { Logger } from 'zos-lib';
 
 const ZOS_SESSION_PATH = '.zos.session';
@@ -8,7 +8,7 @@ const ZOS_SESSION_PATH = '.zos.session';
 export function getNetwork() {
   var networkName = undefined;
   try {
-    networkName = fs.read(ZOS_SESSION_PATH).toString();
+    networkName = fs.readFileSync(ZOS_SESSION_PATH).toString();
   } catch(e) {
   }
 
@@ -21,14 +21,16 @@ export function setNetwork({ network = undefined, remove = false }) {
   }
 
   let log = new Logger('scripts/session');
+
   if (remove) {
-    // no unlink in FileSystem?
-    fs.write(ZOS_SESSION_PATH, '');
-    log.info(`Cleared ${ZOS_SESSION_PATH}.`);
+    if (fs.existsSync(ZOS_SESSION_PATH)) {
+      fs.unlinkSync(ZOS_SESSION_PATH);
+    }
+    log.info(`Removed ${ZOS_SESSION_PATH}.`);
     return;
   }
 
-  fs.write(ZOS_SESSION_PATH, network);
+  fs.writeFileSync(ZOS_SESSION_PATH, network);
   log.info(`Using "${network}" as default network unless overriden.`);
 }
 

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -1,14 +1,11 @@
 import Truffle from '../models/truffle/Truffle';
-import { FileSystem as fs } from 'zos-lib';
+import { getNetwork as getSessionNetworkOrUndefined } from '../scripts/session';
 
 export default async function runWithTruffle(script, network, compile = false) {
   const config = Truffle.config()
 
   if (!network) {
-    try {
-      network = fs.read('/tmp/.zos_session').toString()
-    } catch(e) {
-    }
+    network = getSessionNetworkOrUndefined();
   }
 
   if(!network) throw Error('A network name must be provided to execute the requested action.')

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -1,12 +1,10 @@
 import Truffle from '../models/truffle/Truffle';
-import { getNetwork as getSessionNetworkOrUndefined } from '../scripts/session';
+import { getNetwork as getSessionNetwork } from '../scripts/session';
 
 export default async function runWithTruffle(script, network, compile = false) {
   const config = Truffle.config()
 
-  if (!network) {
-    network = getSessionNetworkOrUndefined();
-  }
+  network = network || getSessionNetwork();
 
   if(!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -1,7 +1,16 @@
 import Truffle from '../models/truffle/Truffle';
+import { FileSystem as fs } from 'zos-lib';
 
 export default async function runWithTruffle(script, network, compile = false) {
   const config = Truffle.config()
+
+  if (!network) {
+    try {
+      network = fs.read('/tmp/.zos_session').toString()
+    } catch(e) {
+    }
+  }
+
   if(!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network
   if (compile) await Truffle.compile(config)

--- a/test/scripts/session.test.js
+++ b/test/scripts/session.test.js
@@ -23,7 +23,7 @@ describe('session', function () {
         error = e;
       }
       error.toString().should.deep.eq(
-        'Please provide either --network <network> or --close.');
+        'Error: Please provide either --network <network> or --close.');
     });
 
     it('setNetwork should throw', function() {
@@ -34,7 +34,7 @@ describe('session', function () {
         error = e;
       }
       error.toString().should.deep.eq(
-        'Please provide either --network <network> or --close.');
+        'Error: Please provide either --network <network> or --close.');
     });
 
     // to remove .zos.session

--- a/test/scripts/session.test.js
+++ b/test/scripts/session.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+require('../setup');
+
+import { getNetwork, setNetwork } from '../../src/scripts/session';
+
+describe('session', function () {
+  describe('getNetwork/setNetwork', function () {
+    it('setNetwork should not throw', () => setNetwork({remove : true}));
+
+    it('getNetwork should return undefined',
+      () => (getNetwork() || 'undefined').should.deep.eq('undefined'));
+
+    it('setNetwork should not throw', () => setNetwork({ network: 'foo' }));
+
+    it('getNetwork should return foo', () => getNetwork().should.deep.eq('foo'));
+
+    it('setNetwork should throw', function() {
+      let error = '';
+      try {
+        setNetwork({});
+      } catch(e) {
+        error = e;
+      }
+      error.toString().should.deep.eq(
+        'Error: Please provide either --network <network> or --remove.');
+    });
+
+    it('setNetwork should throw', function() {
+      let error = '';
+      try {
+        setNetwork({ network: 'foo', remove: true });
+      } catch(e) {
+        error = e;
+      }
+      error.toString().should.deep.eq(
+        'Error: Please provide either --network <network> or --remove.');
+    });
+
+    // to remove .zos.session
+    it('setNetwork should not throw', () => setNetwork({remove : true}));
+  });
+});

--- a/test/scripts/session.test.js
+++ b/test/scripts/session.test.js
@@ -6,7 +6,7 @@ import { getNetwork, setNetwork } from '../../src/scripts/session';
 
 describe('session', function () {
   describe('getNetwork/setNetwork', function () {
-    it('setNetwork should not throw', () => setNetwork({remove : true}));
+    it('setNetwork should not throw', () => setNetwork({close : true}));
 
     it('getNetwork should return undefined',
       () => (getNetwork() || 'undefined').should.deep.eq('undefined'));
@@ -23,21 +23,21 @@ describe('session', function () {
         error = e;
       }
       error.toString().should.deep.eq(
-        'Error: Please provide either --network <network> or --remove.');
+        'Please provide either --network <network> or --close.');
     });
 
     it('setNetwork should throw', function() {
       let error = '';
       try {
-        setNetwork({ network: 'foo', remove: true });
+        setNetwork({ network: 'foo', close: true });
       } catch(e) {
         error = e;
       }
       error.toString().should.deep.eq(
-        'Error: Please provide either --network <network> or --remove.');
+        'Please provide either --network <network> or --close.');
     });
 
     // to remove .zos.session
-    it('setNetwork should not throw', () => setNetwork({remove : true}));
+    it('setNetwork should not throw', () => setNetwork({close : true}));
   });
 });


### PR DESCRIPTION
Fixes #122 

Commands like create, freeze, push, status and upgrade will use
<network> unless overriden.

Example:
zos session ropsten
Using "ropsten" as default network unless overriden.
...
zos push
zos create Foo
zos create ERC20 --network=notropsten