### PR TITLE
Added method to check for contracts_build_directory in truffle.js

### DIFF
--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -1,5 +1,6 @@
 import Stdlib from '../stdlib/Stdlib'
 import Truffle from '../truffle/Truffle'
+import contractBuildDirectory from '../../utils/contractBuildDirectory'
 import { Contracts, Logger, FileSystem as fs } from 'zos-lib'
 
 const log = new Logger('LocalController');
@@ -37,18 +38,10 @@ export default class LocalBaseController {
     return false;
   }
 
-  buildDirectory() {
-    const truffleConfig = require(`${process.cwd()}/truffle.js`)
-    if (truffleConfig.contracts_build_directory) {
-      return truffleConfig.contracts_build_directory
-    }
-    return `${process.cwd()}/build/contracts`
-  }
-
   add(contractAlias, contractName) {
     // We are logging an error instead of throwing because a contract may have an empty constructor, 
     // which is fine, but as long as it is declared we will be picking it up
-    const path = `${this.buildDirectory()}/${contractName}.json`
+    const path = `${contractBuildDirectory()}/${contractName}.json`
     if (this.hasConstructor(path)) {
       log.error(`Contract ${contractName} has an explicit constructor. Move it to an initializer function to use it with ZeppelinOS.`)
     }
@@ -57,7 +50,7 @@ export default class LocalBaseController {
   }
 
   addAll() {
-    const folder = this.buildDirectory()
+    const folder = contractBuildDirectory()
     fs.readDir(folder).forEach(file => {
       const path = `${folder}/${file}`
       if(this.hasBytecode(path)) {
@@ -71,7 +64,7 @@ export default class LocalBaseController {
   validateImplementation(contractName) {
     // We are manually checking the build file instead of delegating to Contracts,
     // as Contracts requires initializing the entire truffle stack.
-    const folder = this.buildDirectory()
+    const folder = contractBuildDirectory()
     const path = `${folder}/${contractName}.json`
     if (!fs.exists(path)) {
       throw Error(`Contract ${contractName} not found in folder ${folder}`)

--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -37,10 +37,18 @@ export default class LocalBaseController {
     return false;
   }
 
+  buildDirectory() {
+    const truffleConfig = require(`${process.cwd()}/truffle.js`)
+    if (truffleConfig.contracts_build_directory) {
+      return truffleConfig.contracts_build_directory
+    }
+    return `${process.cwd()}/build/contracts`
+  }
+
   add(contractAlias, contractName) {
     // We are logging an error instead of throwing because a contract may have an empty constructor, 
     // which is fine, but as long as it is declared we will be picking it up
-    const path = `${process.cwd()}/build/contracts/${contractName}.json`
+    const path = `${this.buildDirectory()}/${contractName}.json`
     if (this.hasConstructor(path)) {
       log.error(`Contract ${contractName} has an explicit constructor. Move it to an initializer function to use it with ZeppelinOS.`)
     }
@@ -49,7 +57,7 @@ export default class LocalBaseController {
   }
 
   addAll() {
-    const folder = `${process.cwd()}/build/contracts`
+    const folder = this.buildDirectory()
     fs.readDir(folder).forEach(file => {
       const path = `${folder}/${file}`
       if(this.hasBytecode(path)) {
@@ -63,7 +71,7 @@ export default class LocalBaseController {
   validateImplementation(contractName) {
     // We are manually checking the build file instead of delegating to Contracts,
     // as Contracts requires initializing the entire truffle stack.
-    const folder = `${process.cwd()}/build/contracts`
+    const folder = this.buildDirectory()
     const path = `${folder}/${contractName}.json`
     if (!fs.exists(path)) {
       throw Error(`Contract ${contractName} not found in folder ${folder}`)

--- a/src/models/local/LocalBaseController.js
+++ b/src/models/local/LocalBaseController.js
@@ -96,7 +96,7 @@ export default class LocalBaseController {
   getContractClass(contractAlias) {
     const contractName = this.packageData.contracts[contractAlias];
     if (contractName) {
-      return Contracts.getFromLocal(contractName);
+      return Contracts._getFromBuildDir(contractBuildDirectory(), contractName);
     } else if (this.hasStdlib()) {
       const stdlibName = this.packageData.stdlib.name;
       const contractName = new Stdlib(stdlibName).contract(contractAlias)

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { bytecodeDigest } from '../../utils/digest';
+import contractBuildDirectory from '../../utils/contractBuildDirectory'
 import { Contracts, Logger, FileSystem as fs, App } from 'zos-lib';
 
 const log = new Logger('NetworkController');
@@ -83,7 +84,7 @@ export default class NetworkBaseController {
   }
 
   async uploadContract(contractAlias, contractName) {
-    const contractClass = Contracts.getFromLocal(contractName);
+    const contractClass = Contracts._getFromBuildDir(contractBuildDirectory(), contractName);
     log.info(`Uploading ${contractName} contract as ${contractAlias}`);
     const contractInstance = await this.setImplementation(contractClass, contractAlias);
     this.networkPackage.contracts[contractAlias] = {
@@ -127,7 +128,7 @@ export default class NetworkBaseController {
     const contractName = this.packageData.contracts[contractAlias];
     if (!this.isApplicationContract(contractAlias)) return false;
     if (!this.isContractDeployed(contractAlias)) return true;
-    const contractClass = Contracts.getFromLocal(contractName);
+    const contractClass = Contracts._getFromBuildDir(contractBuildDirectory(), contractName);
     const currentBytecode = bytecodeDigest(contractClass.bytecode);
     const deployedBytecode = this.networkPackage.contracts[contractAlias].bytecodeHash;
     return currentBytecode !== deployedBytecode;

--- a/src/utils/contractBuildDirectory.js
+++ b/src/utils/contractBuildDirectory.js
@@ -1,0 +1,7 @@
+export default function contractBuildDirectory() {
+  const truffleConfig = require(`${process.cwd()}/truffle.js`)
+  if (truffleConfig.contracts_build_directory) {
+    return truffleConfig.contracts_build_directory
+  }
+  return `${process.cwd()}/build/contracts`
+}


### PR DESCRIPTION
Addresses https://github.com/zeppelinos/zos-cli/issues/268

Truffle lets you set custom build directory: https://truffleframework.com/docs/advanced/configuration#contracts_build_directory

Currently, zos assumes `./build/contracts`