### PR TITLE
Enhancements on error reporting

### DIFF
--- a/src/bin/errors.js
+++ b/src/bin/errors.js
@@ -1,7 +1,7 @@
 import ErrorHandler from '../models/ErrorHandler'
 
 module.exports = function registerErrorHandler(program) {
-  process.on('unhandledRejection', reason => { throw reason; })
+  process.on('unhandledRejection', reason => new ErrorHandler(reason, program).call())
   process.on('uncaughtException', error => new ErrorHandler(error, program).call())
 
   program.on('command:*', function () {

--- a/src/models/truffle/Truffle.js
+++ b/src/models/truffle/Truffle.js
@@ -9,7 +9,11 @@ const Truffle = {
       const TruffleConfig = require('truffle-config')
       return TruffleConfig.detect({ logger: console })
     } catch (error) {
-      throw Error('You have to provide a truffle.js file, please remember to initialize your project running "zos init".')
+      if (error.message === 'Could not find suitable configuration file.') {
+        throw Error('Could not find truffle.js config file, remember to initialize your project running "zos init".')
+      } else {
+        throw Error('Could not load truffle.js config file.\n' + error);
+      }
     }
   },
 


### PR DESCRIPTION
1- Show error reason if loading truffle file fails. If the truffle file is invalid, no error description was shown. Now catches the file missing error and displays the zos init suggestion only then; and displays the error reason otherwise.

2- Display promise rejection via logger instead of throwing the exception. Otherwise a plain stack trace was shown.