### PR TITLE
Add transactions timeout to all commands

### DIFF
--- a/src/commands/compare.js
+++ b/src/commands/compare.js
@@ -12,12 +12,13 @@ const register = program => program
   .description(description)
   .usage('--network <network>')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(options) {
-  const { from, network } = options
+  const { from, network, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await compare({ txParams, network }), network)
+  await runWithTruffle(async () => await compare({ txParams, network }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -16,14 +16,17 @@ const register = program => program
   .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
   .option('-f, --from <from>', 'specify transaction sender address')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('--force', 'force creation even if contracts have local modifications')
   .action(action)
 
 async function action(contractAlias, options) {
   const { initMethod, initArgs } = parseInit(options, 'initialize')
-  const { from, network, force } = options
+  const { from, network, force, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await createProxy({ contractAlias, initMethod, initArgs, network, txParams, force }), network)
+  await runWithTruffle(async () => await createProxy({
+    contractAlias, initMethod, initArgs, network, txParams, force
+  }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/freeze.js
+++ b/src/commands/freeze.js
@@ -13,12 +13,13 @@ const register = program => program
   .description(description)
   .option('-f, --from <from>', 'specify transaction sender address')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(options) {
-  const { from, network } = options
+  const { from, network, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await freeze({ network, txParams }), network)
+  await runWithTruffle(async () => await freeze({ network, txParams }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,6 +17,7 @@ const register = program => program
   .option('--link <stdlib>', 'link to a standard library')
   .option('--no-install', 'skip installing stdlib dependencies locally')
   .option('--push <network>', 'push changes to the specified network')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
   .action(action)
 
@@ -31,7 +32,7 @@ async function action(name, version, options) {
   }
 
   if (options.push) {
-    await push.action({ network: options.push, from: options.from })
+    push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -14,13 +14,14 @@ const register = program => program
   .option('--no-install', 'skip installing stdlib dependencies locally')
   .option('--push <network>', 'push changes to the specified network')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(stdlibNameVersion, options) {
   const installLib = options.install
   await linkStdlib({ stdlibNameVersion, installLib })
   if(options.push) {
-    await push.action({ network: options.push, from: options.from })
+    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -12,12 +12,13 @@ const register = program => program
   .description(description)
   .usage('--network <network>')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(options) {
-  const { from, network } = options
+  const { from, network, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await pull({ txParams, network }), network)
+  await runWithTruffle(async () => await pull({ txParams, network }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -13,15 +13,16 @@ const register = program => program
   .usage('--network <network> [options]')
   .option('-f, --from <from>', 'specify transaction sender address')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('--skip-compile', 'skips contract compilation')
   .option('-d, --deploy-stdlib', 'deploys a copy of the stdlib for development')
   .option('--reset', 'redeploys all contracts (not only the ones that changed)')
   .action(action)
 
 async function action(options) {
-  const { from, network, skipCompile, deployStdlib, reupload } = options
+  const { from, network, skipCompile, deployStdlib, reupload, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, !skipCompile)
+  await runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, { compile: !skipCompile, timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -12,13 +12,14 @@ const register = program => program
   .description(description)
   .usage('--network <network>')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('-f, --from <from>', 'specify transaction sender address')
   .action(action)
 
 async function action(options) {
-  const { from, network } = options
+  const { from, network, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await status({ txParams, network }), network)
+  await runWithTruffle(async () => await status({ txParams, network }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -17,14 +17,17 @@ const register = program => program
   .option('--all', 'upgrade all contracts in the application')
   .option('-f, --from <from>', 'specify transaction sender address')
   .option('-n, --network <network>', 'network to be used')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('--force', 'force creation even if contracts have local modifications')
   .action(action)
 
 async function action(contractAlias, proxyAddress, options) {
   const { initMethod, initArgs } = parseInit(options, 'initialize')
-  const { from, network, all, force } = options
+  const { from, network, all, force, timeout } = options
   const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await upgrade({ contractAlias, proxyAddress, initMethod, initArgs, all, network, txParams, force }), network)
+  await runWithTruffle(async () => await upgrade({ 
+    contractAlias, proxyAddress, initMethod, initArgs, all, network, txParams, force 
+  }), network, { timeout })
 }
 
 export default { name, signature, description, register, action }

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -1,12 +1,17 @@
 import Truffle from '../models/truffle/Truffle';
 import Session from '../models/network/Session'
+import Contracts from 'zos-lib/lib/utils/Contracts';
+import _ from 'lodash';
 
-export default async function runWithTruffle(script, network, compile = false) {
+const DEFAULT_TIMEOUT = 10 * 60; // 10 minutes
+
+export default async function runWithTruffle(script, network, { compile = false, timeout = null }) {
   const config = Truffle.config()
   network = network || Session.getNetwork()
 
   if(!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network
+  Contracts.setSyncTimeout((_.isNil(timeout) ? DEFAULT_TIMEOUT : timeout) * 1000)
   if (compile) await Truffle.compile(config)
   initTruffle(config).then(script)
 }


### PR DESCRIPTION
Add new --timeout flag to all commands that interact with the
blockchain, which is used for timing out on transactions (not
deployments).

Fixes https://github.com/zeppelinos/zos-lib/issues/149