### PR TITLE
Allow stdlib versions to be specified with npm range syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "commander": "^2.15.1",
     "lodash": "^4.17.5",
     "npm-programmatic": "0.0.10",
+    "semver": "^5.5.0",
     "truffle": "^4.1.6",
     "truffle-config": "^1.0.4",
     "truffle-core": "^4.1.8",

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -163,14 +163,20 @@ export default class NetworkAppController extends NetworkBaseController {
 
     const stdlibName = this.packageFile.stdlibName;
     log.info(`Connecting to public deployment of ${stdlibName} in ${this.networkFile.network}`);
-    const stdlibAddress = Stdlib.fetch(stdlibName, this.packageFile.stdlibVersion, this.networkFile.network);
+
+    const { address: stdlibAddress, version: stdlibVersion } = Stdlib.fetch(stdlibName, this.packageFile.stdlibVersion, this.networkFile.network);
     const currentStdlibAddress = await this.app.currentStdlib()
 
-    if(stdlibAddress !== currentStdlibAddress) {
+    if (stdlibAddress !== currentStdlibAddress) {
       await this.app.setStdlib(stdlibAddress);
-      this.networkFile.stdlib = { address: stdlibAddress, ... this.packageFile.stdlib };
+      this.networkFile.stdlib = { 
+         ... this.packageFile.stdlib,
+         address: stdlibAddress, 
+         version: stdlibVersion
+      };
+    } else {
+      log.info(`Current application is already linked to stdlib ${stdlibName} at ${stdlibAddress} in ${this.network}`);
     }
-    else log.info(`Current application is already linked to stdlib ${stdlibName} at ${stdlibAddress} in ${this.network}`);
   }
 
   isStdlibContract(contractAlias) {

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -170,7 +170,7 @@ export default class NetworkAppController extends NetworkBaseController {
     if (stdlibAddress !== currentStdlibAddress) {
       await this.app.setStdlib(stdlibAddress);
       this.networkFile.stdlib = { 
-         ... this.packageFile.stdlib,
+         ... this.packageFile.stdlib, // name, customDeploy
          address: stdlibAddress, 
          version: stdlibVersion
       };

--- a/src/models/stdlib/Stdlib.js
+++ b/src/models/stdlib/Stdlib.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { FileSystem as fs } from 'zos-lib'
+import semver from 'semver';
 
 import StdlibProvider from './StdlibProvider';
 import StdlibDeployer from './StdlibDeployer';
@@ -12,6 +13,10 @@ export default class Stdlib {
 
   static async deploy() {
     return await StdlibDeployer.deploy(...arguments);
+  }
+
+  static satisfies(version, requirement) {
+    return !requirement || version === requirement || semver.satisfies(version, requirement);
   }
 
   constructor(nameAndVersion) {
@@ -45,9 +50,12 @@ export default class Stdlib {
   _parseNameVersion(nameAndVersion) {
     const [name, version] = nameAndVersion.split('@')
     this.name = name
-    const packageVersion = this.getPackage().version;
-    this.version = version || packageVersion
+    this.version = version
     this.nameAndVersion = nameAndVersion
-    if (this.version !== packageVersion) throw Error(`Requested stdlib version ${version} does not match stdlib package version ${packageVersion}`)
+
+    const packageVersion = this.getPackage().version
+    if (!Stdlib.satisfies(packageVersion, version)) {
+      throw Error(`Requested stdlib version ${version} does not match stdlib package version ${packageVersion}`)
+    }
   }
 }

--- a/src/models/stdlib/StdlibProvider.js
+++ b/src/models/stdlib/StdlibProvider.js
@@ -6,9 +6,7 @@ const StdlibProvider = {
     const filename = `node_modules/${name}/zos.${network}.json`
     if(!fs.exists(filename)) throw Error(`Could not find a zos file for network '${network}' for the requested stdlib ${name}@${version}. Please make sure it is provided or at least self-deployed if you are in development mode.`)
     const networkInfo = fs.parseJson(filename)
-    if (!Stdlib.satisfies(networkInfo.version, version)) {
-      throw Error(`Requested stdlib version ${version} does not match stdlib network package version ${networkInfo.version}`)
-    }
+    Stdlib.validateSatisfiesVersion(networkInfo.version, version)
     return {
       address: networkInfo.provider.address,
       version: networkInfo.version

--- a/src/models/stdlib/StdlibProvider.js
+++ b/src/models/stdlib/StdlibProvider.js
@@ -1,12 +1,18 @@
 import { FileSystem as fs } from 'zos-lib'
+import Stdlib from './Stdlib';
 
 const StdlibProvider = {
   from(name, version, network) {
     const filename = `node_modules/${name}/zos.${network}.json`
     if(!fs.exists(filename)) throw Error(`Could not find a zos file for network '${network}' for the requested stdlib ${name}@${version}. Please make sure it is provided or at least self-deployed if you are in development mode.`)
     const networkInfo = fs.parseJson(filename)
-    if(version !== networkInfo.version) throw Error(`Requested stdlib version ${version} does not match stdlib network package version ${networkInfo.version}`)
-    return networkInfo.provider.address
+    if (!Stdlib.satisfies(networkInfo.version, version)) {
+      throw Error(`Requested stdlib version ${version} does not match stdlib network package version ${networkInfo.version}`)
+    }
+    return {
+      address: networkInfo.provider.address,
+      version: networkInfo.version
+    }
   }
 }
 

--- a/test/mocks/packages/package-with-stdlib-range.zos.json
+++ b/test/mocks/packages/package-with-stdlib-range.zos.json
@@ -1,0 +1,9 @@
+{
+  "name": "Herbs",
+  "version": "1.1.0",
+  "contracts": {},
+  "stdlib": {
+    "name": "mock-stdlib",
+    "version": "^1.0.0"
+  }
+}

--- a/test/models/Stdlib.test.js
+++ b/test/models/Stdlib.test.js
@@ -3,6 +3,8 @@ require('../setup')
 
 import Stdlib from '../../src/models/stdlib/Stdlib'
 
+const should = require('chai').should()
+
 contract('Stdlib', function () {
   const packageName = 'mock-stdlib'
 
@@ -14,7 +16,7 @@ contract('Stdlib', function () {
         const version = '1.1.0'
 
         it('should return the address of the stdlib', function () {
-          Stdlib.fetch(packageName, version, network).should.be.nonzeroAddress
+          Stdlib.fetch(packageName, version, network).address.should.be.nonzeroAddress
         })
       })
 
@@ -50,8 +52,8 @@ contract('Stdlib', function () {
       this.stdlib.name.should.eq(packageName)
     })
 
-    it('should set a version', async function () {
-      this.stdlib.version.should.eq('1.1.0')
+    it('should not set a version if not specified', async function () {
+      should.not.exist(this.stdlib.version)
     })
 
     it('should list all provided contracts', async function () {

--- a/test/models/Stdlib.test.js
+++ b/test/models/Stdlib.test.js
@@ -25,7 +25,7 @@ contract('Stdlib', function () {
 
         it('throws an error', function () {
           expect(() => Stdlib.fetch(packageName, version, network))
-            .to.throw('Requested stdlib version 2.0.0 does not match stdlib network package version 1.1.0')
+            .to.throw('Required stdlib version 2.0.0 does not match stdlib package version 1.1.0')
         })
       })
     })
@@ -52,8 +52,8 @@ contract('Stdlib', function () {
       this.stdlib.name.should.eq(packageName)
     })
 
-    it('should not set a version if not specified', async function () {
-      should.not.exist(this.stdlib.version)
+    it('should set latest version with caret if not specified', async function () {
+      this.stdlib.version.should.eq('^1.1.0')
     })
 
     it('should list all provided contracts', async function () {

--- a/test/scripts/link.test.js
+++ b/test/scripts/link.test.js
@@ -35,7 +35,7 @@ contract('link script', function() {
 
   it('should raise an error if requested version of stdlib does not match its package version', async function () {
     await linkStdlib({ stdlibNameVersion: 'mock-stdlib-invalid@1.0.0', packageFile: this.packageFile })
-      .should.be.rejectedWith('Requested stdlib version 1.0.0 does not match stdlib package version 2.0.0')
+      .should.be.rejectedWith('Required stdlib version 1.0.0 does not match stdlib package version 2.0.0')
   });
 
   it('should install the stdlib if a valid version range is requested', async function () {
@@ -49,11 +49,11 @@ contract('link script', function() {
     await linkStdlib({ stdlibNameVersion: 'mock-stdlib', installLib: true, packageFile: this.packageFile });
 
     this.packageFile.stdlibName.should.eq('mock-stdlib');
-    should.not.exist(this.packageFile.stdlibVersion);
+    this.packageFile.stdlibVersion.should.eq('^1.1.0');
   });
 
   it('should raise an error if requested version range does not match its package version', async function () {
     await linkStdlib({ stdlibNameVersion: 'mock-stdlib@~1.0.0', packageFile: this.packageFile })
-      .should.be.rejectedWith('Requested stdlib version ~1.0.0 does not match stdlib package version 1.1.0')
+      .should.be.rejectedWith('Required stdlib version ~1.0.0 does not match stdlib package version 1.1.0')
   });
 });

--- a/test/scripts/link.test.js
+++ b/test/scripts/link.test.js
@@ -4,6 +4,8 @@ require('../setup')
 import linkStdlib from '../../src/scripts/link.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
+const should = require('chai').should();
+
 contract('link script', function() {
 
   beforeEach('setup', async function() {
@@ -34,5 +36,24 @@ contract('link script', function() {
   it('should raise an error if requested version of stdlib does not match its package version', async function () {
     await linkStdlib({ stdlibNameVersion: 'mock-stdlib-invalid@1.0.0', packageFile: this.packageFile })
       .should.be.rejectedWith('Requested stdlib version 1.0.0 does not match stdlib package version 2.0.0')
+  });
+
+  it('should install the stdlib if a valid version range is requested', async function () {
+    await linkStdlib({ stdlibNameVersion: 'mock-stdlib@^1.0.0', installLib: true, packageFile: this.packageFile });
+
+    this.packageFile.stdlibName.should.eq('mock-stdlib');
+    this.packageFile.stdlibVersion.should.eq('^1.0.0');
+  });
+
+  it('should install the stdlib if no version is requested', async function () {
+    await linkStdlib({ stdlibNameVersion: 'mock-stdlib', installLib: true, packageFile: this.packageFile });
+
+    this.packageFile.stdlibName.should.eq('mock-stdlib');
+    should.not.exist(this.packageFile.stdlibVersion);
+  });
+
+  it('should raise an error if requested version range does not match its package version', async function () {
+    await linkStdlib({ stdlibNameVersion: 'mock-stdlib@~1.0.0', packageFile: this.packageFile })
+      .should.be.rejectedWith('Requested stdlib version ~1.0.0 does not match stdlib package version 1.1.0')
   });
 });

--- a/test/scripts/push.test.js
+++ b/test/scripts/push.test.js
@@ -156,7 +156,7 @@ contract('push script', function([_, owner]) {
       await push({ network, txParams, networkFile: this.newNetworkFile })
       this.newNetworkFile.frozen.should.be.false;
     });
-  }
+  };
 
   const shouldDeleteContracts = function () {
     it('should delete contracts', async function () {
@@ -166,6 +166,22 @@ contract('push script', function([_, owner]) {
       const _package = await Package.fetch(this.networkFile.package.address);
       (await _package.getImplementation(defaultVersion, 'Impl')).should.be.zeroAddress;
       should.not.exist(this.networkFile.contract('Impl'));
+    });
+  };
+
+  const shouldSetStdlib = function () {
+    const stdlibAddress = '0x0000000000000000000000000000000000000010';
+
+    it('should set stdlib in deployed app', async function () {
+      const app = await App.fetch(this.networkFile.appAddress);
+      const stdlib = await app.currentStdlib();
+
+      stdlib.should.eq(stdlibAddress);
+    });
+
+    it('should set address and version in network file', async function () {
+      this.networkFile.stdlibAddress.should.eq(stdlibAddress);
+      this.networkFile.stdlibVersion.should.eq('1.1.0');
     });
   };
 
@@ -207,8 +223,6 @@ contract('push script', function([_, owner]) {
   });
 
   describe('an app with stdlib', function () {
-    const stdlibAddress = '0x0000000000000000000000000000000000000010';
-
     describe('when using a valid stdlib', function () {
       beforeEach('pushing package-stdlib', async function () {
         const packageFile = new ZosPackageFile('test/mocks/packages/package-with-stdlib.zos.json')
@@ -218,17 +232,19 @@ contract('push script', function([_, owner]) {
       });
 
       shouldDeployApp();
+      shouldSetStdlib();
+    })
 
-      it('should set stdlib in deployed app', async function () {
-        const app = await App.fetch(this.networkFile.appAddress);
-        const stdlib = await app.currentStdlib();
+    describe('when using an stdlib with a version range', function () {
+      beforeEach('pushing package-stdlib', async function () {
+        const packageFile = new ZosPackageFile('test/mocks/packages/package-with-stdlib-range.zos.json')
+        this.networkFile = packageFile.networkFile(network)
 
-        stdlib.should.eq(stdlibAddress);
+        await push({ networkFile: this.networkFile, network, txParams })
       });
 
-      it('should set address in network file', async function () {
-        this.networkFile.stdlibAddress.should.eq(stdlibAddress);
-      });
+      shouldDeployApp();
+      shouldSetStdlib();
     })
 
     describe('when using an invalid stdlib', function () {

--- a/test/scripts/push.test.js
+++ b/test/scripts/push.test.js
@@ -255,7 +255,7 @@ contract('push script', function([_, owner]) {
 
       it('should set address in network file', async function () {
         await push({ network, txParams, networkFile: this.networkFile })
-          .should.be.rejectedWith('Requested stdlib version 1.0.0 does not match stdlib network package version 3.0.0')
+          .should.be.rejectedWith('Required stdlib version 1.0.0 does not match stdlib package version 3.0.0')
       });
     })
   });


### PR DESCRIPTION
An stdlib version can now be set using npm semver range syntax,
such as ^1.0.0 or ~1.3.0. When linking to a stdlib, the zos.json
file will store the range requirement, and the zos.network.json
file will act as a sort of "lock", storing the actual version
used for deployment. If the actual version does not match the
requirement, an error is thrown.

Fixes #217 