### PR TITLE
Ensure no more than one instance of CLI is running simultaneously

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5430,6 +5430,14 @@
         }
       }
     },
+    "lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "requires": {
+        "signal-exit": "^3.0.2"
+      }
+    },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "commander": "^2.15.1",
+    "lockfile": "^1.0.4",
     "lodash": "^4.17.5",
     "npm-programmatic": "0.0.10",
     "truffle": "^4.1.6",

--- a/src/bin/zos-cli.js
+++ b/src/bin/zos-cli.js
@@ -1,7 +1,17 @@
 #! /usr/bin/env node
 
 import { Logger } from 'zos-lib'
+import { lockSync } from 'lockfile';
 import program from './program'
+
+// Acquire file lock to ensure no other instance is running
+const LOCKFILE = '.zos.lock';
+try { 
+  lockSync(LOCKFILE, { retries: 0 }) 
+} catch (e) { 
+  console.error(`Cannot run more than one instance of 'zos' at the same time.\nIf you are sure that no other instances are actually running, manually remove the file ${LOCKFILE} and try again.`);
+  process.exit(1); 
+}
 
 Logger.silent(false)
 program.parse(process.argv)


### PR DESCRIPTION
Use npm/lockfile to acquire unique lock on a .zos.lock local file and exit the CLI if cannot. Fixes #168.