### PR TITLE
Session command fixes and improvements

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -30,9 +30,7 @@ async function action(contractNames, options) {
     })
     add({ contractsData })
   }
-  if (options.push) {
-    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
-  }
+  await push.tryAction(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -14,8 +14,9 @@ const register = program => program
   .usage('[contractName1[:contractAlias1] ... contractNameN[:contractAliasN]] [options]')
   .description(description)
   .option('--all', 'add all contracts in your build directory')
-  .option('--push <network>', 'push changes to the specified network after adding')
+  .option('--push [network]', 'push changes to the specified network after adding')
   .option('-f, --from <from>', 'specify the transaction sender address for --push')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('--skip-compile', 'skips contract compilation')
   .action(action)
 
@@ -29,8 +30,8 @@ async function action(contractNames, options) {
     })
     add({ contractsData })
   }
-  if(options.push) {
-    await push.action({ network: options.push, from: options.from })
+  if (options.push) {
+    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/bump.js
+++ b/src/commands/bump.js
@@ -14,14 +14,15 @@ const register = program => program
   .option('--link <stdlib>', 'link to new standard library version')
   .option('--no-install', 'skip installing stdlib dependencies locally')
   .option('--push <network>', 'push changes to the specified network after bumping version')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
   .action(action)
 
 async function action(version, options) {
   const { link: stdlibNameVersion, install: installLib } = options
   await bump({ version, stdlibNameVersion, installLib })
-  if(options.push) {
-    await push.action({ network: options.push, from: options.from })
+  if (options.push) {
+    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/bump.js
+++ b/src/commands/bump.js
@@ -13,7 +13,7 @@ const register = program => program
   .description(description)
   .option('--link <stdlib>', 'link to new standard library version')
   .option('--no-install', 'skip installing stdlib dependencies locally')
-  .option('--push <network>', 'push changes to the specified network after bumping version')
+  .option('--push [network]', 'push changes to the specified network after bumping version')
   .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
   .action(action)
@@ -21,9 +21,7 @@ const register = program => program
 async function action(version, options) {
   const { link: stdlibNameVersion, install: installLib } = options
   await bump({ version, stdlibNameVersion, installLib })
-  if (options.push) {
-    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
-  }
+  await push.tryAction(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/compare.js
+++ b/src/commands/compare.js
@@ -16,9 +16,7 @@ const register = program => program
   .action(action)
 
 async function action(options) {
-  const { from, network, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await compare({ txParams, network }), network, { timeout })
+  await runWithTruffle(async (opts) => await compare(opts), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -22,11 +22,10 @@ const register = program => program
 
 async function action(contractAlias, options) {
   const { initMethod, initArgs } = parseInit(options, 'initialize')
-  const { from, network, force, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await createProxy({
-    contractAlias, initMethod, initArgs, network, txParams, force
-  }), network, { timeout })
+  const { force } = options
+  await runWithTruffle(async (opts) => await createProxy({
+    contractAlias, initMethod, initArgs, force, ... opts
+  }), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/freeze.js
+++ b/src/commands/freeze.js
@@ -17,9 +17,7 @@ const register = program => program
   .action(action)
 
 async function action(options) {
-  const { from, network, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await freeze({ network, txParams }), network, { timeout })
+  await runWithTruffle(async (opts) => await freeze(opts), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,8 +17,8 @@ const register = program => program
   .option('--link <stdlib>', 'link to a standard library')
   .option('--no-install', 'skip installing stdlib dependencies locally')
   .option('--push <network>', 'push changes to the specified network')
-  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(name, version, options) {
@@ -32,7 +32,7 @@ async function action(name, version, options) {
   }
 
   if (options.push) {
-    push.action({ network: options.push, from: options.from, timeout: options.timeout })
+    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -16,7 +16,7 @@ const register = program => program
   .option('--force', 'overwrite existing project if there is one')
   .option('--link <stdlib>', 'link to a standard library')
   .option('--no-install', 'skip installing stdlib dependencies locally')
-  .option('--push <network>', 'push changes to the specified network')
+  .option('--push [network]', 'push changes to the specified network')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
   .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
@@ -30,10 +30,7 @@ async function action(name, version, options) {
     const { stdlib: stdlibNameVersion, install: installLib } = options
     await init({ name, version, stdlibNameVersion, installLib, force })
   }
-
-  if (options.push) {
-    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
-  }
+  await push.tryAction(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -20,7 +20,7 @@ const register = program => program
 async function action(stdlibNameVersion, options) {
   const installLib = options.install
   await linkStdlib({ stdlibNameVersion, installLib })
-  if(options.push) {
+  if (options.push) {
     await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -12,7 +12,7 @@ const register = program => program
   .usage('<stdlib> [options]')
   .description(description)
   .option('--no-install', 'skip installing stdlib dependencies locally')
-  .option('--push <network>', 'push changes to the specified network')
+  .option('--push [network]', 'push changes to the specified network')
   .option('-f, --from <from>', 'specify transaction sender address for --push')
   .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
@@ -20,9 +20,7 @@ const register = program => program
 async function action(stdlibNameVersion, options) {
   const installLib = options.install
   await linkStdlib({ stdlibNameVersion, installLib })
-  if (options.push) {
-    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
-  }
+  await push.tryAction(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/pull.js
+++ b/src/commands/pull.js
@@ -16,9 +16,7 @@ const register = program => program
   .action(action)
 
 async function action(options) {
-  const { from, network, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await pull({ txParams, network }), network, { timeout })
+  await runWithTruffle(async (opts) => await pull(opts), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -2,6 +2,7 @@
 
 import push from '../scripts/push'
 import runWithTruffle from '../utils/runWithTruffle'
+import _ from 'lodash'
 
 const name = 'push'
 const signature = name
@@ -22,9 +23,17 @@ const register = program => program
 async function action(options) {
   const { skipCompile, deployStdlib, reupload } = options
   await runWithTruffle(
-    async (opts) => await push({ deployStdlib, reupload, ... opts }), 
+    async (opts) => await push({ deployStdlib, reupload, ... opts }),
     { compile: !skipCompile, ... options }
   )
 }
 
-export default { name, signature, description, register, action }
+async function tryAction(externalOptions) {
+  if (!externalOptions.push) return;
+  const options = _.omit(externalOptions, 'push');
+  const network = _.isString(externalOptions.push) ? externalOptions.push : undefined;
+  if (network) options.network = network;
+  return action(options)
+}
+
+export default { name, signature, description, register, action, tryAction }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -20,9 +20,11 @@ const register = program => program
   .action(action)
 
 async function action(options) {
-  const { from, network, skipCompile, deployStdlib, reupload, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await push({ network, deployStdlib, reupload, txParams }), network, { compile: !skipCompile, timeout })
+  const { skipCompile, deployStdlib, reupload } = options
+  await runWithTruffle(
+    async (opts) => await push({ deployStdlib, reupload, ... opts }), 
+    { compile: !skipCompile, ... options }
+  )
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -14,12 +14,13 @@ const register = program => program
   .description(description)
   .option('--push <network>', 'push all changes to the specified network after removing')
   .option('-f, --from <from>', 'specify the transaction sender address for --push')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(contracts, options) {
   remove({ contracts })
   if (options.push) {
-    await push.action({ network: options.push, from: options.from })
+    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
   }
 }
 

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -12,16 +12,14 @@ const register = program => program
   .alias('rm')
   .usage('[contract1 ... contractN] [options]')
   .description(description)
-  .option('--push <network>', 'push all changes to the specified network after removing')
+  .option('--push [network]', 'push all changes to the specified network after removing')
   .option('-f, --from <from>', 'specify the transaction sender address for --push')
   .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(contracts, options) {
   remove({ contracts })
-  if (options.push) {
-    await push.action({ network: options.push, from: options.from, timeout: options.timeout })
-  }
+  await push.tryAction(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/session.js
+++ b/src/commands/session.js
@@ -4,19 +4,21 @@ import session from '../scripts/session'
 
 const name = 'session'
 const signature = name
-const description = 'by providing --network <network>, commands like create, freeze, push, status and upgrade will use <network> unless overriden. Use --close to undo.'
+const description = 'by providing network options, commands like create, freeze, push, status and upgrade will use them unless overriden. Use --close to undo.'
 
 const register = program => program
   .command(signature, { noHelp: true })
   .usage('[options]')
   .description(description)
-  .option('-n, --network <network>')
+  .option('-n, --network <network>', 'network to be used')
+  .option('-f, --from <from>', 'specify transaction sender address')
+  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
+  .option('--expires <expires>', 'expiration of the session in seconds (defaults to 900, 15 minutes)')
   .option('--close')
   .action(action)
 
 function action(options) {
-  const { network, close } = options
-  session({ network, close })
+  session(options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/session.js
+++ b/src/commands/session.js
@@ -10,7 +10,7 @@ const register = program => program
   .command(signature, { noHelp: true })
   .usage('[options]')
   .description(description)
-  .option('--network <network>')
+  .option('-n, --network <network>')
   .option('--close')
   .action(action)
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -17,9 +17,7 @@ const register = program => program
   .action(action)
 
 async function action(options) {
-  const { from, network, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await status({ txParams, network }), network, { timeout })
+  await runWithTruffle(async (opts) => await status(opts), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -23,11 +23,10 @@ const register = program => program
 
 async function action(contractAlias, proxyAddress, options) {
   const { initMethod, initArgs } = parseInit(options, 'initialize')
-  const { from, network, all, force, timeout } = options
-  const txParams = from ? { from } : {}
-  await runWithTruffle(async () => await upgrade({ 
-    contractAlias, proxyAddress, initMethod, initArgs, all, network, txParams, force 
-  }), network, { timeout })
+  const { all, force } = options
+  await runWithTruffle(async (opts) => await upgrade({ 
+    contractAlias, proxyAddress, initMethod, initArgs, all, force, ... opts
+  }), options)
 }
 
 export default { name, signature, description, register, action }

--- a/src/models/network/Session.js
+++ b/src/models/network/Session.js
@@ -1,23 +1,31 @@
 import { FileSystem as fs, Logger } from 'zos-lib'
+import _ from 'lodash'
 
 const log = new Logger('Session')
-const TIMEOUT_30_MIN = 30 * 60 * 1000
+const TIMEOUT_15_MIN_IN_SECONDS = 15 * 60
 const ZOS_SESSION_PATH = '.zos.session'
 
 const Session = {
 
-  getNetwork() {
+  getSession() {
     const session = fs.parseJsonIfExists(ZOS_SESSION_PATH) || {}
     const expires = new Date(session.expires)
     if (!session || expires <= new Date()) return undefined
-    log.info(`Using session network '${session.network}'`)
-    return session.network
+    log.info(`Using session with ${describe(session)}`)
+    return _.pick(session, 'network', 'timeout', 'from')
   },
 
-  open(network, timeout = TIMEOUT_30_MIN) {
-    const expirationTimestamp = new Date(new Date().getTime() + timeout)
-    fs.writeJson(ZOS_SESSION_PATH, { network, expires: expirationTimestamp })
-    log.info(`Using '${network}' as default network unless overriden.`)
+  getOptions(overrides) {
+    return {
+      ... this.getSession(),
+      ... overrides
+    }
+  },
+
+  open({ network, from, timeout }, expires = TIMEOUT_15_MIN_IN_SECONDS) {
+    const expirationTimestamp = new Date(new Date().getTime() + expires * 1000)
+    fs.writeJson(ZOS_SESSION_PATH, { network, from, timeout, expires: expirationTimestamp })
+    log.info(`Using ${describe({ network, from, timeout })} by default.`)
   },
 
   close() {
@@ -31,6 +39,14 @@ const Session = {
       fs.append(GIT_IGNORE, `\n${ZOS_SESSION_PATH}\n`)
     }
   }
+}
+
+function describe(session) {
+  return _.compact([
+    session.network && `network ${session.network}`,
+    session.from && `sender address ${session.from}`,
+    session.timeout && `timeout ${session.timeout} seconds`
+  ]).join(', ') || 'no options'
 }
 
 export default Session

--- a/src/models/network/Session.js
+++ b/src/models/network/Session.js
@@ -8,14 +8,18 @@ const ZOS_SESSION_PATH = '.zos.session'
 const Session = {
 
   getSession() {
-    const session = fs.parseJsonIfExists(ZOS_SESSION_PATH) || {}
+    const session = fs.parseJsonIfExists(ZOS_SESSION_PATH)
+    if (_.isEmpty(session)) return undefined
     const expires = new Date(session.expires)
-    if (!session || expires <= new Date()) return undefined
-    log.info(`Using session with ${describe(session)}`)
+    if (expires <= new Date()) return undefined
     return _.pick(session, 'network', 'timeout', 'from')
   },
 
-  getOptions(overrides) {
+  getOptions(overrides = {}) {
+    const session = this.getSession();
+    if (!session) return overrides;
+    log.info(`Using session with ${describe(_.omitBy(session, (v,key) => overrides[key]))}`)
+    
     return {
       ... this.getSession(),
       ... overrides

--- a/src/scripts/session.js
+++ b/src/scripts/session.js
@@ -1,7 +1,10 @@
 'use strict';
 import Session from "../models/network/Session";
 
-export default function session({ network = undefined, close = false, timeout = undefined }) {
-  if ((!network && !close) || (network && close)) throw Error('Please provide either --network <network> or --close.')
-  close ? Session.close() : Session.open(network, timeout)
+export default function session({ network, from, timeout, close = false, expires }) {
+  const anyNetworkOption = network || from || timeout;
+  if (!!anyNetworkOption === !!close) {
+    throw Error('Please provide either a network option (--network, --timeout, --from) or --close.')
+  }
+  close ? Session.close() : Session.open({ network, from, timeout }, expires)
 }

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -5,15 +5,15 @@ import _ from 'lodash';
 
 const DEFAULT_TIMEOUT = 10 * 60; // 10 minutes
 
-export default async function runWithTruffle(script, { network, from, compile = false, timeout = null }) {
+export default async function runWithTruffle(script, options) {
   const config = Truffle.config()
-  network = network || Session.getNetwork()
+  const { network, from, timeout } = Session.getOptions(options)
   const txParams = from ? { from } : {}
 
   if (!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network
   Contracts.setSyncTimeout((_.isNil(timeout) ? DEFAULT_TIMEOUT : timeout) * 1000)
-  if (compile) await Truffle.compile(config)
+  if (options.compile) await Truffle.compile(config)
   initTruffle(config).then(() => script({ network, txParams }))
 }
 
@@ -21,7 +21,7 @@ function initTruffle(config) {
   return new Promise((resolve, reject) => {
     const TruffleEnvironment = require('truffle-core/lib/environment')
     TruffleEnvironment.detect(config, function (error) {
-      if (error) throw error
+      if (error) reject(error)
       const Web3 = require('web3')
       global.web3 = new Web3(config.provider)
       global.artifacts = config.resolver

--- a/src/utils/runWithTruffle.js
+++ b/src/utils/runWithTruffle.js
@@ -5,15 +5,16 @@ import _ from 'lodash';
 
 const DEFAULT_TIMEOUT = 10 * 60; // 10 minutes
 
-export default async function runWithTruffle(script, network, { compile = false, timeout = null }) {
+export default async function runWithTruffle(script, { network, from, compile = false, timeout = null }) {
   const config = Truffle.config()
   network = network || Session.getNetwork()
+  const txParams = from ? { from } : {}
 
-  if(!network) throw Error('A network name must be provided to execute the requested action.')
+  if (!network) throw Error('A network name must be provided to execute the requested action.')
   config.network = network
   Contracts.setSyncTimeout((_.isNil(timeout) ? DEFAULT_TIMEOUT : timeout) * 1000)
   if (compile) await Truffle.compile(config)
-  initTruffle(config).then(script)
+  initTruffle(config).then(() => script({ network, txParams }))
 }
 
 function initTruffle(config) {

--- a/test/scripts/session.test.js
+++ b/test/scripts/session.test.js
@@ -8,41 +8,47 @@ describe('session script', function () {
 
   afterEach(() => Session.close())
 
+  const opts = { network: 'foo', from: '0x1', timeout: 10 }
+
   describe('opening a new session', function () {
     describe('when there was no session opened before', function () {
       describe('when the time out does not expire', function () {
-        it('sets the new network', function () {
-          session({ network: 'foo' })
-
-          Session.getNetwork().should.be.equal('foo')
+        beforeEach(function () {
+          session(opts)
+        })
+        it('sets the new options', function () {
+          Session.getOptions().should.be.deep.equal(opts)
+        })
+        it('merges given options with session defaults', function () {
+          Session.getOptions({ from: '0x2' }).should.be.deep.equal({ network: 'foo', timeout: 10, from: '0x2' })
         })
       })
 
       describe('when the time out expires', function () {
-        it('replaces the previous network', function () {
-          session({ network: 'foo', timeout: 0 })
-
-          assert(Session.getNetwork() === undefined)
+        it('clears all options', function () {
+          session({ ... opts, expires: 0 })
+          Session.getOptions().should.be.empty
+        })
+        it('returns given options', function () {
+          Session.getOptions({ from: '0x2' }).should.be.deep.equal({ from: '0x2' })
         })
       })
     })
 
-    describe('when there was no session opened before', function () {
-      beforeEach(() => session({ network: 'foo' }))
+    describe('when there was a session opened before', function () {
+      beforeEach(() => session(opts))
 
       describe('when the time out does not expire', function () {
-        it('replaces the previous network', function () {
+        it('replaces all options', function () {
           session({ network: 'bar' })
-
-          Session.getNetwork().should.be.equal('bar')
+          Session.getOptions().should.be.deep.equal({ network: 'bar' })
         })
       })
 
       describe('when the time out expires', function () {
-        it('replaces the previous network', function () {
-          session({ network: 'bar', timeout: 0 })
-
-          assert(Session.getNetwork() === undefined)
+        it('clears all options', function () {
+          session({ network: 'bar', expires: 0 })
+          Session.getOptions().should.be.empty;
         })
       })
     })
@@ -52,31 +58,31 @@ describe('session script', function () {
     describe('when there was no session opened before', function () {
       it('sets the new network', function () {
         session({ close: true })
-
-        assert(Session.getNetwork() === undefined)
+        Session.getOptions().should.be.empty
       })
     })
 
-    describe('when there was no session opened before', function () {
-      beforeEach(() => session({ network: 'foo' }))
+    describe('when there was a session opened before', function () {
+      beforeEach(() => session(opts))
 
       it('replaces the previous network', function () {
         session({ close: true })
-
-        assert(Session.getNetwork() === undefined)
+        Session.getOptions().should.be.empty
       })
     })
   })
 
-  describe('when no arguments are given', function () {
-    it('throws an error', function () {
-      expect(() => session({})).to.throw('Please provide either --network <network> or --close.')
+  describe('arguments', function () {
+    describe('when no arguments are given', function () {
+      it('throws an error', function () {
+        expect(() => session({})).to.throw('Please provide either a network option (--network, --timeout, --from) or --close.')
+      })
     })
-  })
 
-  describe('when both arguments are given', function () {
-    it('throws an error', function () {
-      expect(() => session({ network: 'boo', close: true })).to.throw('Please provide either --network <network> or --close.')
+    describe('when both arguments are given', function () {
+      it('throws an error', function () {
+        expect(() => session({ network: 'boo', close: true })).to.throw('Please provide either a network option (--network, --timeout, --from) or --close.')
+      })
     })
   })
 })


### PR DESCRIPTION
- Use session defaults in commands with --push option. Network session was not being considered. Now the value for --push is optional, and is loaded from the session network if present.
- Add --timeout option to commands with --push option. The timeout gets passed to the push action if called.
- Support `from` and `timeout` options in `Session` command. Handle more options in the session model, which are merged into the options passed by runWithTruffle. Also, added support for expires to choose for how many seconds the session is valid. Fixes #297.
- Add alias `-n` for network option in session command.
- Handle network related options from `runWithTruffle` wrapper. This ensures that network is correctly passed down to the scripts, as runWithTruffle checks the current session always. Fixes #294. Fixes #289.