### PR TITLE
Fix compare command

### DIFF
--- a/src/commands/compare.js
+++ b/src/commands/compare.js
@@ -12,7 +12,6 @@ const register = program => program
   .description(description)
   .usage('--network <network>')
   .option('-n, --network <network>', 'network to be used')
-  .option('--timeout <timeout>', 'timeout in seconds for blockchain transactions')
   .action(action)
 
 async function action(options) {

--- a/src/models/status/EventsFilter.js
+++ b/src/models/status/EventsFilter.js
@@ -18,12 +18,19 @@ export default class EventsFilter {
   }
 
   async _promiseTimeout(promise) {
-    const timeout = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         clearTimeout(timer)
         reject(TIMEOUT_ERROR)
       }, this.timeout)
+
+      promise.then((res) => {
+        clearTimeout(timer)
+        resolve(res)
+      }).catch((err) => {
+        clearTimeout(timeout)
+        reject(err)
+      })
     })
-    return Promise.race([promise, timeout])
   }
 }

--- a/src/models/status/StatusReport.js
+++ b/src/models/status/StatusReport.js
@@ -7,7 +7,7 @@ export default class StatusReport {
 
   log(logger) {
     logger.error(this.description)
-    logger.error(` - on-chain: ${this.expected}`)
-    logger.warn(` - local:   ${this.observed}\n`)
+    logger.error(` - local: ${this.expected}`)
+    logger.warn(` - on-chain:   ${this.observed}\n`)
   }
 }

--- a/src/models/status/StatusReport.js
+++ b/src/models/status/StatusReport.js
@@ -7,7 +7,7 @@ export default class StatusReport {
 
   log(logger) {
     logger.error(this.description)
-    logger.error(` - expected: ${this.expected}`)
-    logger.warn(` - actual:   ${this.observed}\n`)
+    logger.error(` - on-chain: ${this.expected}`)
+    logger.warn(` - local:   ${this.observed}\n`)
   }
 }


### PR DESCRIPTION
- Removes `--timeout` option (Fixes #308)
- Renames expected and actual to on-chain and local (Fixes #309)
- Fixes `EventsFilter` to clear timeout when the main promise resolves, which caused compare and pull to hang (Fixes #307)