### PR TITLE
Support creating non-upgradeable contract instances

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,12 +1,12 @@
 'use strict';
 
-import createProxy from '../scripts/create'
+import create from '../scripts/create'
 import runWithTruffle from '../utils/runWithTruffle'
 import { parseInit } from '../utils/input'
 
 const name = 'create'
 const signature = `${name} <alias>`
-const description = 'deploys a new upgradeable contract instance. Provide the <alias> you added your contract with'
+const description = 'deploys a new contract instance, upgradeable by default. Provide the <alias> you added your contract with'
 
 const register = program => program
   .command(signature, { noHelp: true })
@@ -15,14 +15,15 @@ const register = program => program
   .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
   .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
   .option('--force', 'force creation even if contracts have local modifications')
+  .option('--no-upgradeable', 'create a non-upgradeable instance of a contract')
   .withNetworkOptions()
   .action(action)
 
 async function action(contractAlias, options) {
   const { initMethod, initArgs } = parseInit(options, 'initialize')
-  const { force } = options
-  await runWithTruffle(async (opts) => await createProxy({
-    contractAlias, initMethod, initArgs, force, ... opts
+  const { upgradeable, force } = options
+  await runWithTruffle(async (opts) => await create({
+    contractAlias, initMethod, initArgs, force, upgradeable, ... opts
   }), options)
 }
 

--- a/src/models/files/ZosNetworkFile.js
+++ b/src/models/files/ZosNetworkFile.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
+import Stdlib from '../stdlib/Stdlib'
 import { Logger, FileSystem as fs } from 'zos-lib'
 import { bytecodeDigest, bodyCode, constructorCode } from '../../utils/contracts'
-import Stdlib from '../stdlib/Stdlib';
 
 const log = new Logger('ZosNetworkFile')
 
@@ -12,7 +12,7 @@ export default class ZosNetworkFile {
     this.network = network
     this.fileName = fileName
 
-    const defaults = this.packageFile.isLib ? { contracts: {}, lib: true, frozen: false } : { contracts: {}, proxies: {}, nonUpgradeableInstances: {} }
+    const defaults = this.packageFile.isLib ? { contracts: {}, lib: true, frozen: false } : { contracts: {}, instances: {} }
     this.data = fs.parseJsonIfExists(this.fileName) || defaults
   }
 
@@ -65,11 +65,15 @@ export default class ZosNetworkFile {
   }
 
   get proxies() {
-    return this.data.proxies || {}
+    return this.instanceAliases.reduce((previous, alias) => {
+      const instances = this.instancesOf(alias)
+      if (instances.length >= 0) previous[alias] = instances
+      return previous
+    }, {})
   }
 
-  get nonUpgradeableInstances() {
-    return this.data.nonUpgradeableInstances || {}
+  get instances() {
+    return this.data.instances || {}
   }
 
   get contracts() {
@@ -80,8 +84,8 @@ export default class ZosNetworkFile {
     return Object.keys(this.contracts)
   }
 
-  get proxyAliases() {
-    return Object.keys(this.proxies)
+  get instanceAliases() {
+    return Object.keys(this.instances)
   }
 
   get isLib() {
@@ -89,35 +93,31 @@ export default class ZosNetworkFile {
   }
 
   proxiesList() {
-    return _.flatMap(this.proxyAliases, alias => this.proxiesOf(alias).map(info => {
+    return _.flatMap(this.instanceAliases, alias => this.proxiesOf(alias).map(info => {
       info['alias'] = alias
       return info
     }))
   }
 
-  proxy(alias, index) {
-    return this.proxiesOf(alias)[index]
+  instance(alias, index) {
+    return this.instancesOf(alias)[index]
   }
 
-  proxyByAddress(alias, address) {
-    const index = this.indexOfProxy(alias, address)
-    return this.proxiesOf(alias)[index]
+  instanceByAddress(alias, address) {
+    const index = this.indexOfInstance(alias, address)
+    return this.instancesOf(alias)[index]
+  }
+
+  instancesOf(alias) {
+    return this.instances[alias] || []
   }
 
   proxiesOf(alias) {
-    return this.proxies[alias] || []
+    return this.instancesOf(alias).filter(instance => instance.upgradeable)
   }
 
-  indexOfProxy(alias, address) {
-    return this.proxiesOf(alias).findIndex(proxy => proxy.address === address)
-  }
-
-  nonUpgradeableInstance(alias, index) {
-    return this.nonUpgradeableInstancesOf(alias)[index]
-  }
-
-  nonUpgradeableInstancesOf(alias) {
-    return this.nonUpgradeableInstances[alias] || []
+  indexOfInstance(alias, address) {
+    return this.instancesOf(alias).findIndex(instance => instance.address === address)
   }
 
   contract(alias) {
@@ -144,8 +144,8 @@ export default class ZosNetworkFile {
     return alias ? !_.isEmpty(this.proxiesOf(alias)) : !_.isEmpty(this.proxies)
   }
 
-  hasNonUpgradeableInstances(alias = undefined) {
-    return alias ? !_.isEmpty(this.nonUpgradeableInstancesOf(alias)) : !_.isEmpty(this.nonUpgradeableInstances)
+  hasInstances(alias = undefined) {
+    return alias ? !_.isEmpty(this.instancesOf(alias)) : !_.isEmpty(this.instances)
   }
 
   hasMatchingVersion() {
@@ -233,39 +233,30 @@ export default class ZosNetworkFile {
     delete this.data.contracts[alias]
   }
 
-  setProxies(alias, value) {
-    this.data.proxies[alias] = value
+  setInstances(alias, value) {
+    this.data.instances[alias] = value
   }
 
   unsetContract(alias) {
     delete this.data.contracts[alias];
   }
 
-  addProxy(alias, info) {
-    if (!this.hasProxies(alias)) this.setProxies(alias, [])
-    this.data.proxies[alias].push(info)
+  addInstance(alias, info) {
+    if (!this.hasInstances(alias)) this.setInstances(alias, [])
+    this.data.instances[alias].push(info)
   }
 
-  setProxyImplementation(alias, address, implementation) {
-    const index = this.indexOfProxy(alias, address)
+  setInstanceImplementation(alias, address, implementation) {
+    const index = this.indexOfInstance(alias, address)
     if(index < 0) return
-    this.data.proxies[alias][index].implementation = implementation
+    this.data.instances[alias][index].implementation = implementation
   }
 
-  removeProxy(alias, address) {
-    const index = this.indexOfProxy(alias, address)
+  removeInstance(alias, address) {
+    const index = this.indexOfInstance(alias, address)
     if(index < 0) return
-    this.data.proxies[alias].splice(index, 1)
-    if(this.proxiesOf(alias).length === 0) delete this.data.proxies[alias]
-  }
-
-  setNonUpgradeableInstances(alias, value) {
-    this.data.nonUpgradeableInstances[alias] = value
-  }
-
-  addNonUpgradeableInstance(alias, info) {
-    if (!this.hasNonUpgradeableInstances(alias)) this.setNonUpgradeableInstances(alias, [])
-    this.data.nonUpgradeableInstances[alias].push(info)
+    this.data.instances[alias].splice(index, 1)
+    if(this.instancesOf(alias).length === 0) delete this.data.instances[alias]
   }
 
   write() {

--- a/src/models/files/ZosNetworkFile.js
+++ b/src/models/files/ZosNetworkFile.js
@@ -12,7 +12,7 @@ export default class ZosNetworkFile {
     this.network = network
     this.fileName = fileName
 
-    const defaults = this.packageFile.isLib ? { contracts: {}, lib: true, frozen: false } : { contracts: {}, proxies: {} }
+    const defaults = this.packageFile.isLib ? { contracts: {}, lib: true, frozen: false } : { contracts: {}, proxies: {}, nonUpgradeableInstances: {} }
     this.data = fs.parseJsonIfExists(this.fileName) || defaults
   }
 
@@ -68,6 +68,10 @@ export default class ZosNetworkFile {
     return this.data.proxies || {}
   }
 
+  get nonUpgradeableInstances() {
+    return this.data.nonUpgradeableInstances || {}
+  }
+
   get contracts() {
     return this.data.contracts || {}
   }
@@ -108,6 +112,14 @@ export default class ZosNetworkFile {
     return this.proxiesOf(alias).findIndex(proxy => proxy.address === address)
   }
 
+  nonUpgradeableInstance(alias, index) {
+    return this.nonUpgradeableInstancesOf(alias)[index]
+  }
+
+  nonUpgradeableInstancesOf(alias) {
+    return this.nonUpgradeableInstances[alias] || []
+  }
+
   contract(alias) {
     return this.contracts[alias]
   }
@@ -130,6 +142,10 @@ export default class ZosNetworkFile {
 
   hasProxies(alias = undefined) {
     return alias ? !_.isEmpty(this.proxiesOf(alias)) : !_.isEmpty(this.proxies)
+  }
+
+  hasNonUpgradeableInstances(alias = undefined) {
+    return alias ? !_.isEmpty(this.nonUpgradeableInstancesOf(alias)) : !_.isEmpty(this.nonUpgradeableInstances)
   }
 
   hasMatchingVersion() {
@@ -241,6 +257,15 @@ export default class ZosNetworkFile {
     if(index < 0) return
     this.data.proxies[alias].splice(index, 1)
     if(this.proxiesOf(alias).length === 0) delete this.data.proxies[alias]
+  }
+
+  setNonUpgradeableInstances(alias, value) {
+    this.data.nonUpgradeableInstances[alias] = value
+  }
+
+  addNonUpgradeableInstance(alias, info) {
+    if (!this.hasNonUpgradeableInstances(alias)) this.setNonUpgradeableInstances(alias, [])
+    this.data.nonUpgradeableInstances[alias].push(info)
   }
 
   write() {

--- a/src/models/files/ZosNetworkFile.js
+++ b/src/models/files/ZosNetworkFile.js
@@ -65,11 +65,7 @@ export default class ZosNetworkFile {
   }
 
   get proxies() {
-    return this.instanceAliases.reduce((previous, alias) => {
-      const instances = this.instancesOf(alias)
-      if (instances.length >= 0) previous[alias] = instances
-      return previous
-    }, {})
+    return _.mapValues(this.instances, instances => _.filter(instances, 'upgradeable'))
   }
 
   get instances() {
@@ -93,10 +89,7 @@ export default class ZosNetworkFile {
   }
 
   proxiesList() {
-    return _.flatMap(this.instanceAliases, alias => this.proxiesOf(alias).map(info => {
-      info['alias'] = alias
-      return info
-    }))
+    return _.flatMap(this.instanceAliases, alias => this.proxiesOf(alias).map(info => Object.assign(info, { alias })))
   }
 
   instance(alias, index) {

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -1,9 +1,50 @@
 import _ from 'lodash';
 import Stdlib from '../stdlib/Stdlib';
 import NetworkBaseController from './NetworkBaseController';
-import { Contracts, Logger, App, FileSystem as fs } from 'zos-lib';
+import { Contracts, Logger, App, FileSystem as fs, encodeCall } from 'zos-lib';
 
 const log = new Logger('NetworkAppController');
+
+// TODO: Remove after upgrade to latest zos-lib version
+App.prototype.createNonUpgradeableInstance = async function(contractClass, contractName, initMethodName, initArgs) {
+  // log.info(`Creating new non-upgradeable instance of ${contractName}...`)
+  const implementationAddress = (await this.getImplementation(contractName)).replace('0x', '');
+
+  // This is EVM assembly will return of the code of a foreign address.
+  //
+  // operation    | bytecode   | stack representation
+  // =================================================
+  // push20 ADDR  | 0x73 ADDR  | ADDR
+  // dup1         | 0x80       | ADDR ADDR
+  // extcodesize  | 0x3B       | ADDR 0xCS
+  // dup1         | 0x80       | ADDR 0xCS 0xCS
+  // swap2        | 0x91       | 0xCS 0xCS ADDR
+  // push1 00     | 0x60 0x00  | 0xCS 0xCS ADDR 0x00
+  // dup1         | 0x80       | 0xCS 0xCS ADDR 0x00 0x00
+  // swap2        | 0x91       | 0xCS 0xCS 0x00 0x00 ADDR
+  // extcodecopy  | 0x3C       | 0xCS
+  // push1 00     | 0x60 0x00  | 0xCS 0x00
+  // return       | 0xF3       |
+
+  const ASM_CODE_COPY = `0x73${implementationAddress}803b8091600080913c6000f3`;
+
+  const params = Object.assign({}, contractClass.defaults(), this.txParams, { to: 0x0, data: ASM_CODE_COPY })
+  const txHash = await web3.eth.sendTransaction(params)
+  const receipt = await web3.eth.getTransactionReceipt(txHash)
+  const instance = contractClass.at(receipt.contractAddress)
+  // log.info(`${contractName} instance created at ${instance.address}`)
+
+  if(typeof(initArgs) !== 'undefined') {
+    // this could be front-run
+    // log.info(`Initializing ${contractName} instance at ${instance.address}`)
+    const initMethod = this._validateInitMethod(contractClass, initMethodName, initArgs)
+    const initArgTypes = initMethod.inputs.map(input => input.type)
+    const callData = encodeCall(initMethodName, initArgTypes, initArgs)
+    await instance.sendTransaction(Object.assign({}, this.txParams, { data: callData }))
+  }
+
+  return instance
+}
 
 export default class NetworkAppController extends NetworkBaseController {
   get isDeployed() {
@@ -52,23 +93,26 @@ export default class NetworkAppController extends NetworkBaseController {
     return this.app.unsetImplementation(contractAlias);
   }
 
-  async createProxy(contractAlias, initMethod, initArgs) {
+  async createInstance(contractAlias, upgradeable, initMethod, initArgs) {
     await this.fetch();
     const contractClass = this.localController.getContractClass(contractAlias);
-    this.checkInitialization(contractClass, initMethod, initArgs);
-    const proxyInstance = await this.app.createProxy(contractClass, contractAlias, initMethod, initArgs);
-    const implementationAddress = await this.app.getImplementation(contractAlias);
-    this._updateTruffleDeployedInformation(contractAlias, proxyInstance)
+    this.checkInitialization(contractClass, initMethod);
+    const instance = upgradeable
+      ? await this.app.createProxy(contractClass, contractAlias, initMethod, initArgs)
+      : await this.app.createNonUpgradeableInstance(contractClass, contractAlias, initMethod, initArgs)
 
-    this.networkFile.addProxy(contractAlias, {
-      address: proxyInstance.address,
-      version: this.app.version,
-      implementation: implementationAddress
-    })
-    return proxyInstance;
+    this._updateTruffleDeployedInformation(contractAlias, instance)
+    const implementation = await this.app.getImplementation(contractAlias);
+    const info = { address: instance.address, version: this.app.version, implementation }
+
+    upgradeable
+      ? this.networkFile.addProxy(contractAlias, info)
+      : this.networkFile.addNonUpgradeableInstance(contractAlias, info)
+
+    return instance;
   }
 
-  checkInitialization(contractClass, calledInitMethod, calledInitArgs) {
+  checkInitialization(contractClass, calledInitMethod) {
     // If there is an initializer called, assume it's ok
     if (calledInitMethod) return;
 
@@ -169,9 +213,9 @@ export default class NetworkAppController extends NetworkBaseController {
 
     if (stdlibAddress !== currentStdlibAddress) {
       await this.app.setStdlib(stdlibAddress);
-      this.networkFile.stdlib = { 
+      this.networkFile.stdlib = {
          ... this.packageFile.stdlib, // name, customDeploy
-         address: stdlibAddress, 
+         address: stdlibAddress,
          version: stdlibVersion
       };
     } else {

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -29,8 +29,8 @@ App.prototype.createNonUpgradeableInstance = async function(contractClass, contr
   const ASM_CODE_COPY = `0x73${implementationAddress}803b8091600080913c6000f3`;
 
   const params = Object.assign({}, contractClass.defaults(), this.txParams, { to: 0x0, data: ASM_CODE_COPY })
-  const txHash = await web3.eth.sendTransaction(params)
-  const receipt = await web3.eth.getTransactionReceipt(txHash)
+  const txHash = web3.eth.sendTransaction(params)
+  const receipt = web3.eth.getTransactionReceipt(txHash)
   const instance = contractClass.at(receipt.contractAddress)
   log.info(`${contractName} instance created at ${instance.address}`)
 

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -43,8 +43,8 @@ export default class NetworkBaseController {
     await statusFetcher.call()
   }
 
-  async createProxy() {
-    throw Error('Unimplemented function create()')
+  async createInstance() {
+    throw Error('Unimplemented function createInstance()')
   }
 
   async push(reupload = false) {

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -44,7 +44,7 @@ export default class NetworkBaseController {
   }
 
   async createProxy() {
-    throw Error('Unimplemented function createProxy()')
+    throw Error('Unimplemented function create()')
   }
 
   async push(reupload = false) {

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -57,7 +57,7 @@ export default class NetworkBaseController {
     const requestedVersion = this.packageFile.version;
     const currentVersion = this.networkFile.version;
     if (requestedVersion !== currentVersion) {
-      log.info(`Currennt version ${currentVersion}`);
+      log.info(`Current version ${currentVersion}`);
       log.info(`Creating new version ${requestedVersion}`);
       const provider = await this.newVersion(requestedVersion);
       this.networkFile.contracts = {};

--- a/src/models/network/NetworkLibController.js
+++ b/src/models/network/NetworkLibController.js
@@ -8,8 +8,8 @@ export default class NetworkLibController extends NetworkBaseController {
     return !!this.packageAddress;
   }
 
-  async createProxy() {
-    throw Error('Cannot create proxy for stdlib')
+  async createInstance() {
+    throw Error('Cannot create contract instances for a stdlib')
   }
 
   async deploy() {

--- a/src/models/status/StatusFetcher.js
+++ b/src/models/status/StatusFetcher.js
@@ -74,24 +74,24 @@ export default class StatusFetcher {
 
   onUnregisteredLocalProxy(expected, observed, { alias, address, implementation }) {
     log.info(`Removing unregistered local proxy of ${alias} at ${address} pointing to ${implementation}`)
-    this.networkFile.removeProxy(alias, address)
+    this.networkFile.removeInstance(alias, address)
   }
 
   onMissingRemoteProxy(expected, observed, { alias, address, implementation }) {
     log.info(`Adding missing proxy of ${alias} at ${address} pointing to ${implementation}`)
-    this.networkFile.addProxy(alias, { address, implementation, version: 'unknown' })
+    this.networkFile.addInstance(alias, { address, implementation, upgradeable: true, version: 'unknown' })
   }
 
   onMismatchingProxyAlias(expected, observed, { alias, address, implementation }) {
     log.info(`Changing alias of proxy at ${address} pointing to ${implementation} from ${expected} to ${observed}`)
-    const proxy = this.networkFile.proxyByAddress(expected, address)
-    this.networkFile.removeProxy(expected, address)
-    this.networkFile.addProxy(alias, proxy)
+    const proxy = this.networkFile.instanceByAddress(expected, address)
+    this.networkFile.removeInstance(expected, address)
+    this.networkFile.addInstance(alias, proxy)
   }
 
   onMismatchingProxyImplementation(expected, observed, { alias, address, implementation }) {
     log.info(`Changing implementation of proxy ${alias} at ${address} from ${expected} to ${observed}`)
-    this.networkFile.setProxyImplementation(alias, address, implementation)
+    this.networkFile.setInstanceImplementation(alias, address, implementation)
   }
 
   onUnregisteredProxyImplementation(expected, observed, { address, implementation }) {

--- a/src/scripts/create.js
+++ b/src/scripts/create.js
@@ -1,7 +1,7 @@
 import stdout from '../utils/stdout';
 import ControllerFor from '../models/network/ControllerFor';
 
-export default async function createProxy({ contractAlias, initMethod, initArgs, network, txParams = {}, force = false, networkFile = undefined }) {
+export default async function create({ contractAlias, initMethod, initArgs, network, txParams = {}, force = false, networkFile = undefined }) {
   if (!contractAlias) throw Error('A contract alias must be provided to create a new proxy.')
 
   const controller = ControllerFor(network, txParams, networkFile)

--- a/src/scripts/create.js
+++ b/src/scripts/create.js
@@ -1,14 +1,14 @@
 import stdout from '../utils/stdout';
 import ControllerFor from '../models/network/ControllerFor';
 
-export default async function create({ contractAlias, initMethod, initArgs, network, txParams = {}, force = false, networkFile = undefined }) {
-  if (!contractAlias) throw Error('A contract alias must be provided to create a new proxy.')
+export default async function create({ contractAlias, initMethod, initArgs, network, txParams = {}, force = false, upgradeable = true, networkFile = undefined }) {
+  if (!contractAlias) throw Error('A contract alias must be provided to create a new instance.')
 
   const controller = ControllerFor(network, txParams, networkFile)
   await controller.checkLocalContractDeployed(contractAlias, !force);
-  const proxy = await controller.createProxy(contractAlias, initMethod, initArgs);
+  const instance = await controller.createInstance(contractAlias, upgradeable, initMethod, initArgs)
 
   controller.writeNetworkPackage();
-  stdout(proxy.address);
-  return proxy;
+  stdout(instance.address);
+  return instance;
 }

--- a/test/models/StatusComparator.test.js
+++ b/test/models/StatusComparator.test.js
@@ -420,9 +420,9 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
 
     describe('when the network file has two proxies', function () {
       beforeEach('adding a proxy', async function () {
-        this.networkFile.setProxies('Impl', [
-          { implementation: this.impl.address, address: '0x1', version: '1.0' },
-          { implementation: this.impl.address, address: '0x2', version: '1.0' }
+        this.networkFile.setInstances('Impl', [
+          { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true },
+          { implementation: this.impl.address, address: '0x2', version: '1.0', upgradeable: true }
         ])
       })
 
@@ -448,9 +448,9 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
         describe('when it matches one proxy address', function () {
           describe('when it matches the alias and the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
+              this.networkFile.setInstances('Impl', [
+                { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true },
+                { implementation: this.impl.address, address: this.proxy.address, version: '1.0', upgradeable: true }
               ])
             })
 
@@ -466,9 +466,9 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
 
           describe('when it matches the alias but not the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
+              this.networkFile.setInstances('Impl', [
+                { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true },
+                { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0', upgradeable: true }
               ])
             })
 
@@ -487,8 +487,8 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
 
           describe('when it matches the implementation address but not the alias', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
+              this.networkFile.setInstances('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true }])
+              this.networkFile.setInstances('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0', upgradeable: true }])
             })
 
             it('reports that diff', async function () {
@@ -506,8 +506,8 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
 
           describe('when it does not match the alias and the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
+              this.networkFile.setInstances('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true }])
+              this.networkFile.setInstances('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0', upgradeable: true }])
             })
 
             it('reports that diff', async function () {

--- a/test/models/StatusFetcher.test.js
+++ b/test/models/StatusFetcher.test.js
@@ -394,7 +394,7 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
         it('does not modoify the proxies list', async function () {
           await this.checker.checkProxies()
 
-          this.networkFile.proxyAliases.should.be.empty
+          this.networkFile.instanceAliases.should.be.empty
         })
       })
 
@@ -406,10 +406,10 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
         it('adds that proxy', async function () {
           await this.checker.checkProxies()
 
-          this.networkFile.proxyAliases.should.have.lengthOf(1)
-          this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-          this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+          this.networkFile.instanceAliases.should.have.lengthOf(1)
+          this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+          this.networkFile.instance('Impl', 0).version.should.be.equal('unknown')
+          this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
         })
       })
 
@@ -422,30 +422,28 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
         it('adds those proxies', async function () {
           await this.checker.checkProxies()
 
-          this.networkFile.proxyAliases.should.have.lengthOf(2)
-          this.networkFile.proxy('Impl', 0).address.should.be.equal(this.implProxy.address)
-          this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-          this.networkFile.proxy('AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
-          this.networkFile.proxy('AnotherImpl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
+          this.networkFile.instanceAliases.should.have.lengthOf(2)
+          this.networkFile.instance('Impl', 0).address.should.be.equal(this.implProxy.address)
+          this.networkFile.instance('Impl', 0).version.should.be.equal('unknown')
+          this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
+          this.networkFile.instance('AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
+          this.networkFile.instance('AnotherImpl', 0).version.should.be.equal('unknown')
+          this.networkFile.instance('AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
         })
       })
     })
 
     describe('when the network file has two proxies', function () {
       beforeEach('adding a proxy', async function () {
-        this.networkFile.setProxies('Impl', [
-          { implementation: this.impl.address, address: '0x1', version: '1.0' },
-          { implementation: this.impl.address, address: '0x2', version: '1.0' }
-        ])
+        this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true })
+        this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x2', version: '1.0', upgradeable: true })
       })
 
       describe('when the app does not have any proxy registered', function () {
         it('removes those proxies', async function () {
           await this.checker.checkProxies()
 
-          this.networkFile.proxyAliases.should.be.empty
+          this.networkFile.instanceAliases.should.be.empty
         })
       })
 
@@ -457,69 +455,65 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
         describe('when it matches one proxy address', function () {
           describe('when it matches the alias and the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
-              ])
+              this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true })
+              this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: this.proxy.address, version: '1.0', upgradeable: true })
             })
 
             it('removes the unregistered proxy', async function () {
               await this.checker.checkProxies()
 
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              this.networkFile.instanceAliases.should.have.lengthOf(1)
+              this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.instance('Impl', 0).version.should.be.equal('1.0')
+              this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
             })
           })
 
           describe('when it matches the alias but not the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
-              ])
+              this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true })
+              this.networkFile.addInstance('Impl', { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0', upgradeable: true })
             })
 
             it('removes the unregistered proxy and updates the implementation of the registered one', async function () {
               await this.checker.checkProxies()
 
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              this.networkFile.instanceAliases.should.have.lengthOf(1)
+              this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.instance('Impl', 0).version.should.be.equal('1.0')
+              this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
             })
           })
 
           describe('when it matches the implementation address but not the alias', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
+              this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true })
+              this.networkFile.addInstance('AnotherImpl', { implementation: this.impl.address, address: this.proxy.address, version: '1.0', upgradeable: true })
             })
 
             it('removes the unregistered proxy and updates the alias of the registered one', async function () {
               await this.checker.checkProxies()
 
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              this.networkFile.instanceAliases.should.have.lengthOf(1)
+              this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.instance('Impl', 0).version.should.be.equal('1.0')
+              this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
             })
           })
 
           describe('when it does not match the alias and the implementation address', function () {
             beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
+              this.networkFile.addInstance('Impl', { implementation: this.impl.address, address: '0x1', version: '1.0', upgradeable: true })
+              this.networkFile.addInstance('AnotherImpl', { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0', upgradeable: true })
             })
 
             it('removes the unregistered proxy and updates the alias and implementation of the registered one', async function () {
               await this.checker.checkProxies()
 
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              this.networkFile.instanceAliases.should.have.lengthOf(1)
+              this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.instance('Impl', 0).version.should.be.equal('1.0')
+              this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
             })
           })
         })
@@ -529,10 +523,10 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
           it('removes the unregistered proxies and adds the registered onen', async function () {
             await this.checker.checkProxies()
 
-            this.networkFile.proxyAliases.should.have.lengthOf(1)
-            this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-            this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-            this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+            this.networkFile.instanceAliases.should.have.lengthOf(1)
+            this.networkFile.instance('Impl', 0).address.should.be.equal(this.proxy.address)
+            this.networkFile.instance('Impl', 0).version.should.be.equal('unknown')
+            this.networkFile.instance('Impl', 0).implementation.should.be.equal(this.impl.address)
           })
         })
       })

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -48,9 +48,10 @@ contract('create script', function([_, owner]) {
     });
 
     const assertInstance = async function(networkFile, alias, { version, say, implementation }) {
-      const instanceInfo = upgradeable ? networkFile.proxy(alias, 0) : networkFile.nonUpgradeableInstance(alias, 0)
+      const instanceInfo = networkFile.instance(alias, 0)
       instanceInfo.address.should.be.nonzeroAddress;
       instanceInfo.version.should.eq(version);
+      instanceInfo.upgradeable.should.be.eq(upgradeable);
 
       if (say) {
         const instance = await ImplV1.at(instanceInfo.address);
@@ -75,7 +76,7 @@ contract('create script', function([_, owner]) {
       await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
 
       const networks = Object.values(Contracts.getFromLocal(contractName).networks)
-      const instanceAddress = this.networkFile.proxy(contractAlias, 0).implementation
+      const instanceAddress = this.networkFile.instance(contractAlias, 0).implementation
       networks.filter(network => network.address === instanceAddress).should.be.have.lengthOf(1)
     });
 
@@ -103,9 +104,7 @@ contract('create script', function([_, owner]) {
       await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
       await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
 
-      upgradeable
-        ? this.networkFile.proxiesOf(contractAlias).should.have.lengthOf(3)
-        : this.networkFile.nonUpgradeableInstancesOf(contractAlias).should.have.lengthOf(3)
+      this.networkFile.instancesOf(contractAlias).should.have.lengthOf(3)
     });
 
     it('should be able to handle instances for more than one contract', async function() {

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -29,167 +29,175 @@ contract('create script', function([_, owner]) {
   const version = '1.1.0';
   const txParams = { from: owner };
 
-  beforeEach('setup', async function() {
-    this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
-    this.networkFile = this.packageFile.networkFile(network)
+  describe('upgradeable instances', function () {
+    shouldAllowToCreateInstances(true)
+  })
 
-    await add({ contractsData, packageFile: this.packageFile });
-    await push({ network, txParams, networkFile: this.networkFile });
-  });
+  describe('non-upgradeable instances', function () {
+    shouldAllowToCreateInstances(false)
+  })
 
-  const assertProxy = async function(networkFile, alias, { version, say, implementation }) {
-    const proxyInfo = networkFile.proxy(alias, 0)
-    proxyInfo.address.should.be.nonzeroAddress;
-    proxyInfo.version.should.eq(version);
+  function shouldAllowToCreateInstances(upgradeable = true) {
 
-    if (say) {
-      const proxy = await ImplV1.at(proxyInfo.address);
-      const said = await proxy.say();
-      said.should.eq(say);
+    beforeEach('setup', async function() {
+      this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+      this.networkFile = this.packageFile.networkFile(network)
+
+      await add({ contractsData, packageFile: this.packageFile });
+      await push({ network, txParams, networkFile: this.networkFile });
+    });
+
+    const assertInstance = async function(networkFile, alias, { version, say, implementation }) {
+      const instanceInfo = upgradeable ? networkFile.proxy(alias, 0) : networkFile.nonUpgradeableInstance(alias, 0)
+      instanceInfo.address.should.be.nonzeroAddress;
+      instanceInfo.version.should.eq(version);
+
+      if (say) {
+        const instance = await ImplV1.at(instanceInfo.address);
+        const said = await instance.say();
+        said.should.eq(say);
+      }
+
+      if (implementation) {
+        instanceInfo.implementation.should.eq(implementation);
+      }
     }
 
-    if (implementation) {
-      proxyInfo.implementation.should.eq(implementation);
-    }
+    it('should create an instance for one of its contracts', async function() {
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+      const implementation = this.networkFile.contract(contractAlias).address;
+      await assertInstance(this.networkFile, contractAlias, { version, say: 'V1', implementation });
+    });
+
+    // TODO: for some reason this test fails on travis
+    xit('should record the deployed instance address in contract build json file', async function () {
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+      const networks = Object.values(Contracts.getFromLocal(contractName).networks)
+      const instanceAddress = this.networkFile.proxy(contractAlias, 0).implementation
+      networks.filter(network => network.address === instanceAddress).should.be.have.lengthOf(1)
+    });
+
+    it('should refuse to create an instance for an undefined contract', async function() {
+      await create({ contractAlias: 'NotExists', network, txParams, upgradeable, networkFile: this.networkFile })
+        .should.be.rejectedWith(/Contract NotExists not found/);
+    });
+
+    it('should refuse to create an instance for a lib project', async function() {
+      this.packageFile.lib = true
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile })
+        .should.be.rejectedWith(`Cannot create contract instances for a stdlib`);
+    });
+
+    it('should refuse to create an instance for an undeployed contract', async function() {
+      const customContractsData = [{ name: contractName, alias: 'NotDeployed' }]
+      await add({ contractsData: customContractsData, packageFile: this.packageFile });
+
+      await create({ contractAlias: 'NotDeployed', network, txParams, upgradeable, networkFile: this.networkFile })
+        .should.be.rejectedWith('Contract NotDeployed is not deployed to test.');
+    });
+
+    it('should be able to have multiple instances for one of its contracts', async function() {
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+      upgradeable
+        ? this.networkFile.proxiesOf(contractAlias).should.have.lengthOf(3)
+        : this.networkFile.nonUpgradeableInstancesOf(contractAlias).should.have.lengthOf(3)
+    });
+
+    it('should be able to handle instances for more than one contract', async function() {
+      await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+      await create({ contractAlias: anotherContractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+      await assertInstance(this.networkFile, contractAlias, { version, say: 'V1' });
+      await assertInstance(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
+    });
+
+    describe('warnings', function () {
+      beforeEach('capturing log output', function () {
+        this.logs = new CaptureLogs();
+      });
+
+      afterEach(function () {
+        this.logs.restore();
+      });
+
+      it('should warn when not initializing an instance with initialize method', async function() {
+        await create({ contractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+        this.logs.errors.should.have.lengthOf(1);
+        this.logs.errors[0].should.match(/make sure you initialize/i);
+      });
+
+      it('should warn when not initializing an instance that inherits from one with an initialize method', async function() {
+        await create({ contractAlias: anotherContractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+        this.logs.errors.should.have.lengthOf(1);
+        this.logs.errors[0].should.match(/make sure you initialize/i);
+      });
+
+      it('should not warn when initializing an instance', async function() {
+        await create({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: [42], upgradeable, networkFile: this.networkFile });
+
+        this.logs.errors.should.have.lengthOf(0);
+      });
+
+      it('should not warn when an instance has not initialize method', async function() {
+        await create({ contractAlias: uninitializableContractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+        this.logs.errors.should.have.lengthOf(0);
+      });
+    });
+
+    describe('with stdlib', function () {
+      beforeEach('setting stdlib', async function () {
+        await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+        await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
+      });
+
+      it('should create an instance for a stdlib contract', async function () {
+        await create({ contractAlias: 'Greeter', network, txParams, upgradeable, networkFile: this.networkFile });
+        await assertInstance(this.networkFile, 'Greeter', { version });
+      });
+    });
+
+    describe('with unpushed stdlib link', function () {
+      beforeEach('setting stdlib', async function () {
+        await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+      });
+
+      it('should refuse create a proxy for a stdlib contract', async function () {
+        await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile })
+          .should.be.rejectedWith(/Contract Greeter is provided by mock-stdlib but it was not deployed to the network/)
+      });
+    });
+
+    describe('with local modifications', function () {
+      beforeEach('changing local network file to have a different bytecode', async function () {
+        const contracts = this.networkFile.contracts
+        contracts[contractAlias].bytecodeHash = '0xabcd'
+        this.networkFile.contracts = contracts
+      });
+
+      it('should refuse to create an instance for a modified contract', async function () {
+        await create({ contractAlias,network, txParams, upgradeable, networkFile: this.networkFile })
+          .should.be.rejectedWith('Contract Impl has changed locally since the last deploy, consider running \'zos push\'.');
+      });
+
+      it('should create an instance for an unmodified contract', async function () {
+        await create({ contractAlias: anotherContractAlias, network, txParams, upgradeable, networkFile: this.networkFile });
+
+        await assertInstance(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
+      });
+
+      it('should create an instance for a modified contract if force is set', async function () {
+        await create({ contractAlias, network, txParams, force: true, upgradeable, networkFile: this.networkFile });
+
+        await assertInstance(this.networkFile, contractAlias, { version, say: 'V1' });
+      });
+    });
   }
-
-  it('should create a proxy for one of its contracts', async function() {
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-
-    const implementation = this.networkFile.contract(contractAlias).address;
-    await assertProxy(this.networkFile, contractAlias, { version, say: 'V1', implementation });
-  });
-
-  // TODO: for some reason this test fails on travis
-  xit('should record the proxy deployed address in contract build json file', async function () {
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-
-    const networks = Object.values(Contracts.getFromLocal(contractName).networks)
-    const proxyAddress = this.networkFile.proxy(contractAlias, 0).implementation
-    networks.filter(network => network.address === proxyAddress).should.be.have.lengthOf(1)
-  });
-
-  it('should refuse to create a proxy for an undefined contract', async function() {
-    await create({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
-      .should.be.rejectedWith(/Contract NotExists not found/);
-  });
-
-  it('should refuse to create a proxy for a lib project', async function() {
-    this.packageFile.lib = true
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile })
-      .should.be.rejectedWith('Cannot create proxy for stdlib');
-  });
-
-  it('should refuse to create a proxy for an undeployed contract', async function() {
-    const customContractsData = [{ name: contractName, alias: 'NotDeployed' }]
-    await add({ contractsData: customContractsData, packageFile: this.packageFile });
-
-    await create({ contractAlias: 'NotDeployed', network, txParams, networkFile: this.networkFile })
-      .should.be.rejectedWith('Contract NotDeployed is not deployed to test.');
-  });
-
-  it('should be able to have multiple proxies for one of its contracts', async function() {
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-
-    this.networkFile.proxiesOf(contractAlias).should.have.lengthOf(3);
-  });
-
-  it('should be able to handle proxies for more than one contract', async function() {
-    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
-
-    await assertProxy(this.networkFile, contractAlias, { version, say: 'V1' });
-    await assertProxy(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
-  });
-
-  describe('warnings', function () {
-    beforeEach('capturing log output', function () {
-      this.logs = new CaptureLogs();
-    });
-
-    afterEach(function () {
-      this.logs.restore();
-    });
-
-    it('should warn when not initializing a contract with initialize method', async function() {
-      await create({ contractAlias, network, txParams, networkFile: this.networkFile });
-
-      this.logs.errors.should.have.lengthOf(1);
-      this.logs.errors[0].should.match(/make sure you initialize/i);
-    });
-
-    it('should warn when not initializing a contract that inherits from one with an initialize method', async function() {
-      await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
-
-      this.logs.errors.should.have.lengthOf(1);
-      this.logs.errors[0].should.match(/make sure you initialize/i);
-    });
-
-    it('should not warn when initializing a contract', async function() {
-      await create({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: [42], networkFile: this.networkFile });
-
-      this.logs.errors.should.have.lengthOf(0);
-    });
-
-    it('should not warn when a contract has not initialize method', async function() {
-      await create({ contractAlias: uninitializableContractAlias, network, txParams, networkFile: this.networkFile });
-
-      this.logs.errors.should.have.lengthOf(0);
-    });
-  });
-
-  describe('with stdlib', function () {
-    beforeEach('setting stdlib', async function () {
-      await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
-      await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
-    });
-
-    it('should create a proxy for a stdlib contract', async function () {
-      await create({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-      await assertProxy(this.networkFile, 'Greeter', { version });
-    });
-  });
-
-  describe('with unpushed stdlib link', function () {
-    beforeEach('setting stdlib', async function () {
-      await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
-    });
-
-    it('should refuse create a proxy for a stdlib contract', async function () {
-      await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile })
-        .should.be.rejectedWith(/Contract Greeter is provided by mock-stdlib but it was not deployed to the network/)
-    });
-  });
-
-  it('should refuse to create a proxy for an undefined contract', async function() {
-    await createProxy({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
-      .should.be.rejectedWith(/Contract NotExists not found/);
-  });
-
-  describe('with local modifications', function () {
-    beforeEach('changing local network file to have a different bytecode', async function () {
-      const contracts = this.networkFile.contracts
-      contracts[contractAlias].bytecodeHash = '0xabcd'
-      this.networkFile.contracts = contracts
-    });
-
-    it('should refuse to create a proxy for a modified contract', async function () {
-      await create({ contractAlias,network, txParams, networkFile: this.networkFile })
-        .should.be.rejectedWith('Contract Impl has changed locally since the last deploy, consider running \'zos push\'.');
-    });
-
-    it('should create a proxy for an unmodified contract', async function () {
-      await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
-
-      await assertProxy(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
-    });
-
-    it('should create a proxy for a modified contract if force is set', async function () {
-      await create({ contractAlias, network, txParams, force: true, networkFile: this.networkFile });
-
-      await assertProxy(this.networkFile, contractAlias, { version, say: 'V1' });
-    });
-  });
 });

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -6,7 +6,7 @@ import { Contracts, Logger } from 'zos-lib';
 
 import add from '../../src/scripts/add.js';
 import push from '../../src/scripts/push.js';
-import createProxy from '../../src/scripts/create.js';
+import create from '../../src/scripts/create.js';
 import linkStdlib from '../../src/scripts/link.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
@@ -54,7 +54,7 @@ contract('create script', function([_, owner]) {
   }
 
   it('should create a proxy for one of its contracts', async function() {
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
 
     const implementation = this.networkFile.contract(contractAlias).address;
     await assertProxy(this.networkFile, contractAlias, { version, say: 'V1', implementation });
@@ -62,7 +62,7 @@ contract('create script', function([_, owner]) {
 
   // TODO: for some reason this test fails on travis
   xit('should record the proxy deployed address in contract build json file', async function () {
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
 
     const networks = Object.values(Contracts.getFromLocal(contractName).networks)
     const proxyAddress = this.networkFile.proxy(contractAlias, 0).implementation
@@ -70,13 +70,13 @@ contract('create script', function([_, owner]) {
   });
 
   it('should refuse to create a proxy for an undefined contract', async function() {
-    await createProxy({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
+    await create({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
       .should.be.rejectedWith(/Contract NotExists not found/);
   });
 
   it('should refuse to create a proxy for a lib project', async function() {
     this.packageFile.lib = true
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile })
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile })
       .should.be.rejectedWith('Cannot create proxy for stdlib');
   });
 
@@ -84,21 +84,21 @@ contract('create script', function([_, owner]) {
     const customContractsData = [{ name: contractName, alias: 'NotDeployed' }]
     await add({ contractsData: customContractsData, packageFile: this.packageFile });
 
-    await createProxy({ contractAlias: 'NotDeployed', network, txParams, networkFile: this.networkFile })
+    await create({ contractAlias: 'NotDeployed', network, txParams, networkFile: this.networkFile })
       .should.be.rejectedWith('Contract NotDeployed is not deployed to test.');
   });
 
   it('should be able to have multiple proxies for one of its contracts', async function() {
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
 
     this.networkFile.proxiesOf(contractAlias).should.have.lengthOf(3);
   });
 
   it('should be able to handle proxies for more than one contract', async function() {
-    await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
-    await createProxy({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias, network, txParams, networkFile: this.networkFile });
+    await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
 
     await assertProxy(this.networkFile, contractAlias, { version, say: 'V1' });
     await assertProxy(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
@@ -114,27 +114,27 @@ contract('create script', function([_, owner]) {
     });
 
     it('should warn when not initializing a contract with initialize method', async function() {
-      await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias, network, txParams, networkFile: this.networkFile });
 
       this.logs.errors.should.have.lengthOf(1);
       this.logs.errors[0].should.match(/make sure you initialize/i);
     });
 
     it('should warn when not initializing a contract that inherits from one with an initialize method', async function() {
-      await createProxy({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
 
       this.logs.errors.should.have.lengthOf(1);
       this.logs.errors[0].should.match(/make sure you initialize/i);
     });
 
     it('should not warn when initializing a contract', async function() {
-      await createProxy({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: [42], networkFile: this.networkFile });
+      await create({ contractAlias, network, txParams, initMethod: 'initialize', initArgs: [42], networkFile: this.networkFile });
 
       this.logs.errors.should.have.lengthOf(0);
     });
 
     it('should not warn when a contract has not initialize method', async function() {
-      await createProxy({ contractAlias: uninitializableContractAlias, network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: uninitializableContractAlias, network, txParams, networkFile: this.networkFile });
 
       this.logs.errors.should.have.lengthOf(0);
     });
@@ -147,7 +147,7 @@ contract('create script', function([_, owner]) {
     });
 
     it('should create a proxy for a stdlib contract', async function () {
-      await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
       await assertProxy(this.networkFile, 'Greeter', { version });
     });
   });
@@ -176,18 +176,18 @@ contract('create script', function([_, owner]) {
     });
 
     it('should refuse to create a proxy for a modified contract', async function () {
-      await createProxy({ contractAlias,network, txParams, networkFile: this.networkFile })
+      await create({ contractAlias,network, txParams, networkFile: this.networkFile })
         .should.be.rejectedWith('Contract Impl has changed locally since the last deploy, consider running \'zos push\'.');
     });
 
     it('should create a proxy for an unmodified contract', async function () {
-      await createProxy({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: anotherContractAlias, network, txParams, networkFile: this.networkFile });
 
       await assertProxy(this.networkFile, anotherContractAlias, { version, say: 'AnotherV1' });
     });
 
     it('should create a proxy for a modified contract if force is set', async function () {
-      await createProxy({ contractAlias, network, txParams, force: true, networkFile: this.networkFile });
+      await create({ contractAlias, network, txParams, force: true, networkFile: this.networkFile });
 
       await assertProxy(this.networkFile, contractAlias, { version, say: 'V1' });
     });

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -169,7 +169,7 @@ contract('create script', function([_, owner]) {
       });
 
       it('should refuse create a proxy for a stdlib contract', async function () {
-        await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile })
+        await create({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile })
           .should.be.rejectedWith(/Contract Greeter is provided by mock-stdlib but it was not deployed to the network/)
       });
     });

--- a/test/scripts/status.test.js
+++ b/test/scripts/status.test.js
@@ -4,7 +4,7 @@ require('../setup')
 import add from '../../src/scripts/add.js';
 import push from '../../src/scripts/push.js';
 import bumpVersion from '../../src/scripts/bump.js';
-import createProxy from '../../src/scripts/create.js';
+import create from '../../src/scripts/create.js';
 import status from '../../src/scripts/status.js';
 import linkStdlib from '../../src/scripts/link';
 import ControllerFor from '../../src/models/local/ControllerFor';
@@ -215,7 +215,7 @@ contract('status script', function([_, owner]) {
       it('should log created proxies', async function () {
         await add({ contractsData, packageFile: this.packageFile });
         await push({ network, txParams, networkFile: this.networkFile });
-        await createProxy({ contractAlias, network, txParams, networkFile: this.networkFile });
+        await create({ contractAlias, network, txParams, networkFile: this.networkFile });
         await status({ network, networkFile: this.networkFile });
         
         this.logs.text.should.match(/Impl at 0x[0-9a-fA-F]{40} version 1.1.0/i);

--- a/test/scripts/update.test.js
+++ b/test/scripts/update.test.js
@@ -88,7 +88,7 @@ contract('update script', function([_, owner]) {
 
     it('should not upgrade a non-upgradeable instance given its address', async function() {
       const instance = this.networkFile.instance('Impl', 2);
-      await upgradeProxy({ contractAlias: 'Impl', proxyAddress: instance.address, network, txParams, networkFile: this.networkFile });
+      await update({ contractAlias: 'Impl', proxyAddress: instance.address, network, txParams, networkFile: this.networkFile });
       this.networkFile.instance('Impl', 2).implementation.should.be.eq(this.implV1Address)
     });
 
@@ -110,7 +110,7 @@ contract('update script', function([_, owner]) {
     });
 
     it('should not upgrade non-upgradeable instances in the app', async function() {
-      await upgradeProxy({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
+      await update({ contractAlias: undefined, proxyAddress: undefined, all: true, network, txParams, networkFile: this.networkFile });
 
       this.networkFile.instance('Impl', 2).implementation.should.be.eq(this.implV1Address)
     });
@@ -221,7 +221,7 @@ contract('update script', function([_, owner]) {
 
       it('should warn when the instance to upgrade is non-upgradeable', async function() {
         const instance = this.networkFile.instance('Impl', 2)
-        await upgradeProxy({ contractAlias: 'Impl', proxyAddress: instance.address, network, txParams, networkFile: this.networkFile })
+        await update({ contractAlias: 'Impl', proxyAddress: instance.address, network, txParams, networkFile: this.networkFile })
 
         this.logs.infos.should.have.lengthOf(1);
         this.logs.infos[0].should.eq('No proxies to upgrade were found');

--- a/test/scripts/update.test.js
+++ b/test/scripts/update.test.js
@@ -6,8 +6,8 @@ import CaptureLogs from '../helpers/captureLogs';
 
 import add from '../../src/scripts/add.js';
 import push from '../../src/scripts/push.js';
-import bumpVersion from '../../src/scripts/bump.js';
-import createProxy from '../../src/scripts/create.js';
+import bump from '../../src/scripts/bump.js';
+import create from '../../src/scripts/create.js';
 import update from '../../src/scripts/update.js';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
@@ -61,12 +61,12 @@ contract('update script', function([_, owner]) {
       this.implV1Address = this.networkFile.contract('Impl').address;
       this.anotherImplV1Address = this.networkFile.contract('AnotherImpl').address;
 
-      await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'Impl', upgradeable: false, network, txParams, networkFile: this.networkFile })
-      await createProxy({ contractAlias: 'AnotherImpl', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Impl', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Impl', upgradeable: false, network, txParams, networkFile: this.networkFile })
+      await create({ contractAlias: 'AnotherImpl', network, txParams, networkFile: this.networkFile });
 
-      await bumpVersion({ version: version_2, txParams, packageFile: this.packageFile });
+      await bump({ version: version_2, txParams, packageFile: this.packageFile });
       const newContractsData = [{ name: 'ImplV2', alias: 'Impl' }, { name: 'AnotherImplV2', alias: 'AnotherImpl' }]
       await add({ contractsData: newContractsData, packageFile: this.packageFile });
       await push({ network, txParams, networkFile: this.networkFile });
@@ -236,10 +236,10 @@ contract('update script', function([_, owner]) {
       this.networkFile = this.packageFile.networkFile(network)
 
       await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-      await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
+      await create({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
 
-      await bumpVersion({ version: version_2, txParams, stdlibNameVersion: 'mock-stdlib-2@1.2.0', packageFile: this.packageFile });
+      await bump({ version: version_2, txParams, stdlibNameVersion: 'mock-stdlib-2@1.2.0', packageFile: this.packageFile });
       await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
     });
 

--- a/test/scripts/update.test.js
+++ b/test/scripts/update.test.js
@@ -24,7 +24,7 @@ contract('update script', function([_, owner]) {
   const txParams = { from: owner };
 
   const assertProxyInfo = async function(networkFile, contractAlias, proxyIndex, { version, implementation, address, value }) {
-    const proxyInfo = networkFile.proxy(contractAlias, proxyIndex);
+    const proxyInfo = networkFile.instance(contractAlias, proxyIndex);
 
     if (address) proxyInfo.address.should.eq(address);
     else proxyInfo.address.should.be.nonzeroAddress;
@@ -75,7 +75,7 @@ contract('update script', function([_, owner]) {
 
     it('should upgrade the version of a proxy given its address', async function() {
       // Upgrade single proxy
-      const proxyAddress = this.networkFile.proxy('Impl', 0).address;
+      const proxyAddress = this.networkFile.instance('Impl', 0).address;
       await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
       await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
 
@@ -109,7 +109,7 @@ contract('update script', function([_, owner]) {
 
     it('should upgrade the remaining proxies if one was already upgraded', async function() {
       // Upgrade a single proxy
-      const proxyAddress = this.networkFile.proxy('Impl', 0).address;
+      const proxyAddress = this.networkFile.instance('Impl', 0).address;
       await update({ contractAlias: 'Impl', proxyAddress, network, txParams, networkFile: this.networkFile });
       await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress });
 
@@ -120,7 +120,7 @@ contract('update script', function([_, owner]) {
     });
 
     it('should upgrade a single proxy and migrate it', async function() {
-      const proxyAddress = this.networkFile.proxy('Impl', 0).address;
+      const proxyAddress = this.networkFile.instance('Impl', 0).address;
       await update({ contractAlias: 'Impl', initMethod: 'migrate', initArgs: [42], proxyAddress, network, txParams, networkFile: this.networkFile });
       await assertProxyInfo(this.networkFile, 'Impl', 0, { version: version_2, implementation: this.implV2Address, address: proxyAddress, value: 42 });
     });
@@ -222,14 +222,14 @@ contract('update script', function([_, owner]) {
     });
 
     it('should upgrade the version of a proxy given its address', async function() {
-      const proxyAddress = this.networkFile.proxy('Greeter', 0).address;
+      const proxyAddress = this.networkFile.instance('Greeter', 0).address;
       await update({ contractAlias: 'Greeter', proxyAddress, network, txParams, networkFile: this.networkFile });
 
       await assertProxyInfo(this.networkFile, 'Greeter', 0, { version: version_2, address: proxyAddress });
       const upgradedProxy = await Greeter_V2.at(proxyAddress);
       (await upgradedProxy.version()).should.eq('1.2.0');
 
-      const anotherProxyAddress = this.networkFile.proxy('Greeter', 1).address;
+      const anotherProxyAddress = this.networkFile.instance('Greeter', 1).address;
       const notUpgradedProxy = await Greeter_V1.at(anotherProxyAddress);
       (await notUpgradedProxy.version()).should.eq('1.1.0');
     });

--- a/test/scripts/update.test.js
+++ b/test/scripts/update.test.js
@@ -224,7 +224,7 @@ contract('update script', function([_, owner]) {
         await update({ contractAlias: 'Impl', proxyAddress: instance.address, network, txParams, networkFile: this.networkFile })
 
         this.logs.infos.should.have.lengthOf(1);
-        this.logs.infos[0].should.eq('No proxies to upgrade were found');
+        this.logs.infos[0].should.eq('No proxies to update were found');
       })
     });
   });


### PR DESCRIPTION
Fixes https://github.com/zeppelinos/zos-lib/issues/32

Analyzing this issue a bit, I thought about two alternatives:

### Using on-chain version of a contract 
The idea of this approach is to allow users to create instances of any contract they have already registered in their `App`s. 

**PRO:** We will be using exactly the same on-chain bytecode
**CON:** Currently, every non-upgradeable instance will follow the current initializers model. This means, even if a user could create an instance of a contract using a constructor function, given that we are registering only contracts without constructors, we will be forcing them to work with initializers.

### Using local version of a contract
This approach could allow users to create instances of any contract they have locally. 

**PRO:** It will allow users to work with constructors instead of the current initializer model.
**CON:** We will not be working with registered implementations. Additionally, we will have to modify the interface of the `create` command of the CLI to support receiving arguments without the initialize method. The last one could be cumbersome.

### Conclusion
I'd go with the first alternative. IMO, working with registered implementations is a must. Although it is not a good idea to force users to work with initializers when creating non-upgradeable instances, we are working on a new initializers model that will solve this issue (constructors are going to be on-chain). Having that said, let's think if we are ok with merging this PR while we keep working on the new initializers model, or if we should do it afterward. 