### PR TITLE
Fail with explicit error when creating proxy for missing stdlib

### DIFF
--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -189,6 +189,15 @@ export default class NetworkAppController extends NetworkBaseController {
     return super.isContractDefined(contractAlias) || this.isStdlibContract(contractAlias);
   }
 
+  _errorForLocalContractDeployed(contractAlias) {
+    const baseErr = super._errorForLocalContractDeployed(contractAlias);
+    if (baseErr) {
+      return baseErr;
+    } else if (this.isStdlibContract(contractAlias) && !this.networkFile.hasStdlib()) {
+      return `Contract ${contractAlias} is provided by ${this.packageFile.stdlibName} but it was not deployed to the network, consider running \`zos push\``;
+    }
+  }
+
   _updateTruffleDeployedInformation(contractAlias, implementation) {
     const contractName = this.packageFile.contract(contractAlias)
     if (contractName) {

--- a/src/models/network/NetworkBaseController.js
+++ b/src/models/network/NetworkBaseController.js
@@ -111,7 +111,8 @@ export default class NetworkBaseController {
   }
 
   checkLocalContractsDeployed(throwIfFail = false) {
-    this._handleErrorMessage(this._errorForLocalContractsDeployed(), throwIfFail);
+    const err = this._errorForLocalContractsDeployed();
+    if (err) this._handleErrorMessage(err, throwIfFail);
   }
 
   _errorForLocalContractsDeployed() {
@@ -126,7 +127,8 @@ export default class NetworkBaseController {
   }
 
   checkLocalContractDeployed(contractAlias, throwIfFail = false) {
-    this._handleErrorMessage(this._errorForLocalContractDeployed(contractAlias), throwIfFail);
+    const err = this._errorForLocalContractDeployed(contractAlias);
+    if (err) this._handleErrorMessage(err, throwIfFail);
   }
 
   _errorForLocalContractDeployed(contractAlias) {
@@ -140,8 +142,11 @@ export default class NetworkBaseController {
   }
 
   _handleErrorMessage(msg, throwIfFail = false) {
-    if (msg && throwIfFail) throw Error(msg);
-    else if (msg) log.info(msg);
+    if (throwIfFail) {
+      throw Error(msg);
+    } else {
+      log.info(msg);
+    }
   }
 
   hasContractChanged(contractAlias) {

--- a/test/scripts/create.test.js
+++ b/test/scripts/create.test.js
@@ -71,7 +71,7 @@ contract('create script', function([_, owner]) {
 
   it('should refuse to create a proxy for an undefined contract', async function() {
     await createProxy({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
-      .should.be.rejectedWith('Contract NotExists not found in application or stdlib');
+      .should.be.rejectedWith(/Contract NotExists not found/);
   });
 
   it('should refuse to create a proxy for a lib project', async function() {
@@ -148,9 +148,24 @@ contract('create script', function([_, owner]) {
 
     it('should create a proxy for a stdlib contract', async function () {
       await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile });
-
       await assertProxy(this.networkFile, 'Greeter', { version });
     });
+  });
+
+  describe('with unpushed stdlib link', function () {
+    beforeEach('setting stdlib', async function () {
+      await linkStdlib({ stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile });
+    });
+
+    it('should refuse create a proxy for a stdlib contract', async function () {
+      await createProxy({ contractAlias: 'Greeter', network, txParams, networkFile: this.networkFile })
+        .should.be.rejectedWith(/Contract Greeter is provided by mock-stdlib but it was not deployed to the network/)
+    });
+  });
+
+  it('should refuse to create a proxy for an undefined contract', async function() {
+    await createProxy({ contractAlias: 'NotExists', network, txParams, networkFile: this.networkFile })
+      .should.be.rejectedWith(/Contract NotExists not found/);
   });
 
   describe('with local modifications', function () {


### PR DESCRIPTION
Creating a proxy for a contract that belongs to an stdlib that was
linked, but that link was not pushed to the network, would yield
a "VM Revert" error. Now it explains that the stdlib is linked but
a push is missing.

Fixes #218 