### PR TITLE
Handle stdlib semver syntax in the `status` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Handle stdlib semver syntax in the `status` command ([#290](https://github.com/zeppelinos/zos-cli/issues/290))
+
 ## v1.1.0
 
 ### Added

--- a/src/models/files/ZosNetworkFile.js
+++ b/src/models/files/ZosNetworkFile.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import { Logger, FileSystem as fs } from 'zos-lib'
 import { bytecodeDigest, bodyCode, constructorCode } from '../../utils/contracts'
+import Stdlib from '../stdlib/Stdlib';
 
 const log = new Logger('ZosNetworkFile')
 
@@ -140,12 +141,11 @@ export default class ZosNetworkFile {
   }
 
   hasMatchingCustomDeploy() {
-    return this.hasCustomDeploy() && this.packageFile.hasStdlib(this.stdlib)
+    return this.hasCustomDeploy() && this.packageFile.stdlibMatches(this.stdlib)
   }
 
-  hasStdlib(stdlib = undefined) {
-    if(stdlib === undefined) return !_.isEmpty(this.stdlib)
-    return this.stdlib.name === stdlib.name && this.stdlib.version === stdlib.version
+  hasStdlib() {
+    return !_.isEmpty(this.stdlib)
   }
 
   hasSameBytecode(alias, klass) {

--- a/src/models/files/ZosPackageFile.js
+++ b/src/models/files/ZosPackageFile.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import ZosNetworkFile from './ZosNetworkFile'
 import { Logger, FileSystem as fs } from 'zos-lib'
+import Stdlib from '../stdlib/Stdlib';
 
 const log = new Logger('ZosPackageFile')
 
@@ -60,8 +61,14 @@ export default class ZosPackageFile {
   }
 
   hasStdlib(stdlib = undefined) {
-    if(stdlib === undefined) return !_.isEmpty(this.stdlib)
-    return this.stdlib.name === stdlib.name && this.stdlib.version === stdlib.version
+    if (stdlib !== undefined) return this.stdlibMatches(stdlib);
+    return !_.isEmpty(this.stdlib)
+  }
+
+  stdlibMatches(stdlib) {
+    return _.isEmpty(this.stdlib) === _.isEmpty(stdlib)
+      && this.stdlib.name === stdlib.name 
+      && Stdlib.satisfiesVersion(stdlib.version, this.stdlib.version)
   }
 
   isCurrentVersion(version) {

--- a/src/models/network/NetworkAppController.js
+++ b/src/models/network/NetworkAppController.js
@@ -155,7 +155,7 @@ export default class NetworkAppController extends NetworkBaseController {
       return
     }
 
-    const customDeployMatches = this.networkFile.hasCustomDeploy() && this.packageFile.hasStdlib(this.networkFile.stdlib)
+    const customDeployMatches = this.networkFile.hasCustomDeploy() && this.packageFile.stdlibMatches(this.networkFile.stdlib)
     if (customDeployMatches) {
       log.info(`Using existing custom deployment of stdlib at ${this.networkFile.stdlibAddress}`);
       return this.app.setStdlib(this.networkFile.stdlibAddress);

--- a/src/scripts/status.js
+++ b/src/scripts/status.js
@@ -100,8 +100,8 @@ async function stdlibInfo(networkFile) {
     log.info(`- Custom deploy of stdlib set at ${networkFile.stdlibAddress}`);
   } else if (networkFile.hasCustomDeploy()) {
     log.info(`- Custom deploy of different stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion} at ${networkFile.stdlibAddress}`);
-  } else if (packageFile.hasStdlib(networkFile.stdlib)) {
-    log.info(`- Deployed application is correctly connected to stdlib`);
+  } else if (packageFile.stdlibMatches(networkFile.stdlib)) {
+    log.info(`- Deployed application is correctly connected to stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion}`);
   } else {
     log.warn(`- Deployed application is connected to different stdlib ${networkFile.stdlibName}@${networkFile.stdlibVersion}`);
   }

--- a/test/scripts/init.test.js
+++ b/test/scripts/init.test.js
@@ -55,7 +55,7 @@ contract('init script', function() {
 
       this.packageFile.stdlibName.should.eq('mock-stdlib');
       this.packageFile.stdlibVersion.should.eq('1.1.0');
-      this.packageFile.hasStdlib({ name: 'mock-stdlib', version: '1.1.0'}).should.be.true;
+      this.packageFile.stdlibMatches({ name: 'mock-stdlib', version: '1.1.0'}).should.be.true;
     });
 
     it('should not overwrite existing file by default', async function () {

--- a/test/scripts/status.test.js
+++ b/test/scripts/status.test.js
@@ -164,6 +164,16 @@ contract('status script', function([_, owner]) {
         this.logs.text.should.match(/correctly connected to stdlib/i);
       });
 
+      it('should log connected stdlib when semver requirement matches', async function () {
+        await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib@^1.0.0', installLib: false });
+        await push({ network, txParams, networkFile: this.networkFile });
+        await status({ network, networkFile: this.networkFile });
+
+        this.logs.text.should.match(/mock-stdlib@\^1\.0\.0 required/i);
+        this.logs.text.should.match(/correctly connected to stdlib/i);
+        this.logs.text.should.match(/1\.1\.0/i);
+      });
+
       it('should log different stdlib connected', async function () {
         await push({ network, txParams, networkFile: this.networkFile });
         await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib-2@1.2.0', installLib: false });
@@ -181,7 +191,7 @@ contract('status script', function([_, owner]) {
         this.logs.text.should.match(/custom deploy of stdlib set at 0x[0-9a-fA-F]{40}/i);
       });
 
-      it('should log different stdlib connected', async function () {
+      it('should log different stdlib deployed', async function () {
         await push({ network, txParams, deployStdlib: true, networkFile: this.networkFile });
         await linkStdlib({ packageFile: this.packageFile, stdlibNameVersion: 'mock-stdlib-2@1.2.0', installLib: false });
         await status({ network, networkFile: this.networkFile });


### PR DESCRIPTION
Instead of comparing both version strings verbatim, the requirement
in the package file is used as a semver spec.

Also added a method stdlibMatches to package file model, to avoid
using the overloaded version of hasStdlib which may lead to confusion.
Removed the overloaded version from network package, which was not
being used at all.

Fixes #290 