### PR TITLE
Swapped params of TestApp initializer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Handle stdlib semver syntax in the `status` command ([#290](https://github.com/zeppelinos/zos-cli/issues/290))
-<<<<<<< HEAD
 - Better wording from status command when a contract is scheduled to be removed ([#304](https://github.com/zeppelinos/zos-cli/issues/304))
-=======
+- Fail with an explicit error when attempting to create a proxy for an stdlib that was linked but not pushed to the network ([#322](https://github.com/zeppelinos/zos-cli/pull/322))
 - Include default timeout in `--timeout` flag help ([#302](https://github.com/zeppelinos/zos-cli/issues/302))
->>>>>>> Clarify timeout flag and show default value (fixes #302)
+
+### Changed
+- Swapped `TestApp` initializer parameters, it now accepts `txParams` first and an optional `ZosNetworkFile` object as a last argument.
 
 ## v1.1.0
 

--- a/src/models/TestApp.js
+++ b/src/models/TestApp.js
@@ -1,6 +1,12 @@
 import ControllerFor from '../models/network/ControllerFor';
 
-export default async function testApp(networkFile = undefined, txParams = {}) {
+/**
+ * Initializes a zOS application for testing, deploying it to the test network,
+ * along with its standard library (if specified)
+ * @param txParams optional txParams (from, gas, gasPrice) to use on every transaction
+ * @param networkFile optional `ZosNetworkFile` object to use, instead of zos.test.json
+ */
+export default async function testApp(txParams = {}, networkFile = undefined) {
   const controller = new ControllerFor('test', txParams, networkFile)
   await controller.deployStdlib();
   await controller.push();

--- a/test/models/TestApp.test.js
+++ b/test/models/TestApp.test.js
@@ -6,7 +6,6 @@ import testApp from '../../src/models/TestApp';
 import ZosPackageFile from "../../src/models/files/ZosPackageFile";
 
 const ImplV1 = Contracts.getFromLocal('ImplV1');
-const ImplV2 = Contracts.getFromLocal('ImplV2');
 
 contract('TestApp', function ([_, owner]) {
   const txParams = { from: owner }
@@ -15,7 +14,7 @@ contract('TestApp', function ([_, owner]) {
   beforeEach("deploying all contracts", async function () {
     this.packageFile = new ZosPackageFile('test/mocks/packages/package-with-contracts-and-stdlib.zos.json')
     this.networkFile = this.packageFile.networkFile('test')
-    this.app = await testApp(this.networkFile, txParams)
+    this.app = await testApp(txParams, this.networkFile)
     this.directory = this.app.currentDirectory();
   });
 


### PR DESCRIPTION
Given that txParams is to be used more frequently than the network file object, txParams was moved to the first one. Fixes #333.