### PR TITLE
Fix status compare and status fetch for libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 .zos.session
 zos.*
 build
-lib
+/lib
 .node-xmlhttprequest-sync-*

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Better wording from status command when a contract is scheduled to be removed ([#304](https://github.com/zeppelinos/zos-cli/issues/304))
 - Fail with an explicit error when attempting to create a proxy for an stdlib that was linked but not pushed to the network ([#322](https://github.com/zeppelinos/zos-cli/pull/322))
 - Include default timeout in `--timeout` flag help ([#302](https://github.com/zeppelinos/zos-cli/issues/302))
+<<<<<<< HEAD
 - Fix naming issues of upgrade-command-related files ([#327](https://github.com/zeppelinos/zos-cli/pull/327))
+=======
+- Modes `--fetch` and `--fix` from the `status` command now work properly with lib projects ([#314](https://github.com/zeppelinos/zos-cli/issues/314))
+>>>>>>> Fix status and fetch commands for libs
 
 ### Changed
 - Swapped `TestApp` initializer parameters, it now accepts `txParams` first and an optional `ZosNetworkFile` object as a last argument.

--- a/changelog.md
+++ b/changelog.md
@@ -11,11 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Better wording from status command when a contract is scheduled to be removed ([#304](https://github.com/zeppelinos/zos-cli/issues/304))
 - Fail with an explicit error when attempting to create a proxy for an stdlib that was linked but not pushed to the network ([#322](https://github.com/zeppelinos/zos-cli/pull/322))
 - Include default timeout in `--timeout` flag help ([#302](https://github.com/zeppelinos/zos-cli/issues/302))
-<<<<<<< HEAD
 - Fix naming issues of upgrade-command-related files ([#327](https://github.com/zeppelinos/zos-cli/pull/327))
-=======
 - Modes `--fetch` and `--fix` from the `status` command now work properly with lib projects ([#314](https://github.com/zeppelinos/zos-cli/issues/314))
->>>>>>> Fix status and fetch commands for libs
 
 ### Changed
 - Swapped `TestApp` initializer parameters, it now accepts `txParams` first and an optional `ZosNetworkFile` object as a last argument.

--- a/src/models/lib/PackageAtVersion.js
+++ b/src/models/lib/PackageAtVersion.js
@@ -1,0 +1,56 @@
+import PackageProvider from "zos-lib/lib/package/PackageProvider";
+
+export default class PackageAtVersion {
+
+  static async fetch(address, version, txParams = {}) {
+    const provider = new PackageProvider(txParams)
+    const basePackage = await provider.from(address);
+    const hasVersion = await basePackage.hasVersion(version);
+    if (!hasVersion) throw Error(`Could not find version ${version} in package at ${address}`);
+    const directory = await basePackage.getRelease(version);
+    return new PackageAtVersion(basePackage, version, directory);
+  }
+
+  constructor(_wrapped, _version, _directory) {
+    this.wrapped = _wrapped;
+    this.version = _version;
+
+    this.directories = { }
+    this.directories[_version] = _directory;
+  }
+
+  get package() {
+    return this.wrapped.package;
+  }
+
+  currentDirectory() {
+    return this.directories[this.version];
+  }
+
+  getImplementation(contractName) {
+    return this.wrapped.getImplementation(this.version, contractName);
+  }
+
+  setImplementation(contractClass, contractName) {
+    return this.wrapped.setImplementation(this.version, contractClass, contractName);
+  }
+
+  unsetImplementation(contractName) {
+    return this.wrapped.unsetImplementation(this.version, contractName);
+  }
+
+  async newVersion(version) {
+    const release = await this.wrapped.newVersion(version);
+    this.directories[version] = release;
+    this.version = version;
+    return release;
+  }
+
+  isFrozen() {
+    return this.wrapped.isFrozen(this.version);
+  }
+
+  freeze() {
+    return this.wrapped.freeze(this.version);
+  }
+}

--- a/src/models/status/StatusComparator.js
+++ b/src/models/status/StatusComparator.js
@@ -10,7 +10,7 @@ export default class StatusComparator {
 
   onEndChecking() {
     this.reports.forEach(report => report.log(log))
-    if(this.reports.length === 0) log.info('Your app is up to date.')
+    if(this.reports.length === 0) log.info('Your project is up to date.')
   }
 
   onMismatchingVersion(expected, observed) {
@@ -62,7 +62,7 @@ export default class StatusComparator {
   }
 
   onUnregisteredProxyImplementation(expected, observed, { address, implementation }) {
-    this._addReport(expected, observed, `Proxy at ${address} is pointing to ${implementation} but given implementation is not registered in app`)
+    this._addReport(expected, observed, `Proxy at ${address} is pointing to ${implementation} but given implementation is not registered in project`)
   }
 
   onMultipleProxyImplementations(expected, observed, { implementation }) {

--- a/src/models/status/StatusFetcher.js
+++ b/src/models/status/StatusFetcher.js
@@ -9,7 +9,7 @@ export default class StatusFetcher {
   }
 
   onEndChecking() {
-    log.info('Your app is up to date.')
+    log.info('Your project is up to date.')
   }
 
   onMismatchingVersion(expected, observed) {
@@ -95,10 +95,10 @@ export default class StatusFetcher {
   }
 
   onUnregisteredProxyImplementation(expected, observed, { address, implementation }) {
-    log.error(`Proxy at ${address} is pointing to ${implementation}, but given implementation is not registered in app`)
+    log.error(`Proxy at ${address} is pointing to ${implementation}, but given implementation is not registered in project`)
   }
 
   onMultipleProxyImplementations(expected, observed, { implementation }) {
-    log.warn(`The same implementation address ${implementation} was registered under many aliases (${observed}). Please check them in the list of registered contracts`)
+    log.warn(`The same implementation address ${implementation} was registered under many aliases (${observed}). Please check them in the list of registered contracts.`)
   }
 }

--- a/test/models/StatusComparator.test.js
+++ b/test/models/StatusComparator.test.js
@@ -9,6 +9,7 @@ import { bytecodeDigest } from '../../src/utils/contracts'
 import StatusChecker from '../../src/models/status/StatusChecker'
 import ZosPackageFile from '../../src/models/files/ZosPackageFile'
 import StatusComparator from '../../src/models/status/StatusComparator'
+import PackageAtVersion from '../../src/models/lib/PackageAtVersion';
 
 const ImplV1 = Contracts.getFromLocal('ImplV1')
 const AnotherImplV1 = Contracts.getFromLocal('AnotherImplV1')
@@ -17,534 +18,574 @@ contract('StatusComparator', function([_, owner, anotherAddress]) {
   const network = 'test'
   const txParams = { from: owner }
 
-  beforeEach('initializing network file and status checker', async function () {
-    this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+  describe('app', function () {
+    beforeEach('initializing network file and status checker', async function () {
+      init.call(this, 'test/mocks/packages/package-empty.zos.json');
+    })
+  
+    beforeEach('deploying an app', async function () {
+      await push({ network, txParams, networkFile: this.networkFile })
+      this.app = await App.fetch(this.networkFile.appAddress, txParams)
+    })
+
+    testVersion();
+    testImplementations();
+    testPackage();
+    testProvider();
+    testProxies();
+    testStdlib();
+  });
+
+  describe('lib', function () {
+    beforeEach('initializing network file and status checker', async function () {
+      init.call(this, 'test/mocks/packages/package-empty-lib.zos.json');
+    })
+  
+    beforeEach('deploying a lib', async function () {
+      await push({ network, txParams, networkFile: this.networkFile })
+      this.app = await PackageAtVersion.fetch(this.networkFile.packageAddress, "1.1.0", txParams)
+    })
+
+    testImplementations();
+    testProvider();
+  });
+
+  function init(fileName) {
+    this.packageFile = new ZosPackageFile(fileName)
     this.networkFile = this.packageFile.networkFile(network)
     this.comparator = new StatusComparator()
     this.checker = new StatusChecker(this.comparator, this.networkFile, txParams)
-  })
+  }
 
-  beforeEach('deploying an app', async function () {
-    await push({ network, txParams, networkFile: this.networkFile })
-    this.app = await App.fetch(this.networkFile.appAddress, txParams)
-  })
+  function testVersion () {
+    describe('version', function () {
+      describe('when the network file shows a different version than the one set in the App contract', function () {
+        const newVersion = '2.0.0'
 
-  describe('version', function () {
-    describe('when the network file shows a different version than the one set in the App contract', function () {
-      const newVersion = '2.0.0'
-
-      beforeEach(async function () {
-        await this.app.newVersion(newVersion)
-      })
-
-      it('reports that diff', async function () {
-        await this.checker.checkVersion()
-
-        this.comparator.reports.should.have.lengthOf(1)
-        this.comparator.reports[0].expected.should.be.equal('1.1.0')
-        this.comparator.reports[0].observed.should.be.equal('2.0.0')
-        this.comparator.reports[0].description.should.be.equal('App version does not match')
-      })
-    })
-
-    describe('when the network file version matches with the one in the App contract', function () {
-      it('does not report any diff', async function () {
-        await this.checker.checkVersion()
-
-        this.comparator.reports.should.be.empty
-      })
-    })
-  })
-
-  describe('package', function () {
-    describe('when the network file shows a different package address than the one set in the App contract', function () {
-      beforeEach(async function () {
-        this.networkFile.package = { address: '0x10' }
-      })
-
-      it('reports that diff', async function () {
-        await this.checker.checkPackage()
-
-        this.comparator.reports.should.have.lengthOf(1)
-        this.comparator.reports[0].expected.should.be.equal(this.networkFile.packageAddress)
-        this.comparator.reports[0].observed.should.be.equal(this.app.package.address)
-        this.comparator.reports[0].description.should.be.equal('Package address does not match')
-      })
-    })
-
-    describe('when the network file package matches with the one in the App contract', function () {
-      it('does not report any diff', async function () {
-        await this.checker.checkPackage()
-
-        this.comparator.reports.should.be.empty
-      })
-    })
-  })
-
-  describe('provider', function () {
-    describe('when the network file shows a different provider address than the one set in the App contract', function () {
-      beforeEach(async function () {
-        await this.app.newVersion('2.0.0')
-      })
-
-      it('reports that diff', async function () {
-        await this.checker.checkProvider()
-
-        this.comparator.reports.should.have.lengthOf(1)
-        this.comparator.reports[0].expected.should.be.equal(this.networkFile.providerAddress)
-        this.comparator.reports[0].observed.should.be.equal(this.app.currentDirectory().address)
-        this.comparator.reports[0].description.should.be.equal('Provider address does not match')
-      })
-    })
-
-    describe('when the network file provider matches with the one in the App contract', function () {
-      it('does not report any diff', async function () {
-        await this.checker.checkProvider()
-
-        this.comparator.reports.should.be.empty
-      })
-    })
-  })
-
-  describe('stdlib', function () {
-    describe('when the network file does not specify any stdlib', function () {
-      describe('when the App contract has a stdlib set', function () {
         beforeEach(async function () {
-          await this.app.setStdlib(anotherAddress)
+          await this.app.newVersion(newVersion)
         })
 
         it('reports that diff', async function () {
-          await this.checker.checkStdlib()
+          await this.checker.checkVersion()
 
           this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal(anotherAddress)
-          this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
+          this.comparator.reports[0].expected.should.be.equal('1.1.0')
+          this.comparator.reports[0].observed.should.be.equal('2.0.0')
+          this.comparator.reports[0].description.should.be.equal('App version does not match')
         })
       })
-      
-      describe('when the App contract does not have a stdlib set', function () {
+
+      describe('when the network file version matches with the one in the App contract', function () {
         it('does not report any diff', async function () {
-          await this.checker.checkStdlib()
+          await this.checker.checkVersion()
 
           this.comparator.reports.should.be.empty
         })
       })
     })
+  };
 
-    describe('when the network file has a stdlib', function () {
-      const stdlibAddress = '0x0000000000000000000000000000000000000010'
-
-      beforeEach('set stdlib in network file', async function () {
-        await linkStdlib({stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile})
-        await push({ network, txParams, networkFile: this.networkFile })
-      })
-
-      describe('when the App contract has the same stdlib set', function () {
-        beforeEach('set stdlib in App contract', async function () {
-          await this.app.setStdlib(stdlibAddress)
+  function testPackage () {
+    describe('package', function () {
+      describe('when the network file shows a different package address than the one set in the App contract', function () {
+        beforeEach(async function () {
+          this.networkFile.package = { address: '0x10' }
         })
 
+        it('reports that diff', async function () {
+          await this.checker.checkPackage()
+
+          this.comparator.reports.should.have.lengthOf(1)
+          this.comparator.reports[0].expected.should.be.equal(this.networkFile.packageAddress)
+          this.comparator.reports[0].observed.should.be.equal(this.app.package.address)
+          this.comparator.reports[0].description.should.be.equal('Package address does not match')
+        })
+      })
+
+      describe('when the network file package matches with the one in the App contract', function () {
         it('does not report any diff', async function () {
-          await this.checker.checkStdlib()
+          await this.checker.checkPackage()
 
           this.comparator.reports.should.be.empty
         })
       })
-
-      describe('when the App contract has another stdlib set', function () {
-        beforeEach('set stdlib in App contract', async function () {
-          await this.app.setStdlib(anotherAddress)
-        })
-
-        it('reports that diff', async function () {
-          await this.checker.checkStdlib()
-
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal(stdlibAddress)
-          this.comparator.reports[0].observed.should.be.equal(anotherAddress)
-          this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
-        })
-      })
-
-      describe('when the App contract has no stdlib set', function () {
-        beforeEach('unset App stdlib', async function () {
-          await this.app.setStdlib(0x0)
-        })
-
-        it('reports that diff', async function () {
-          await this.checker.checkStdlib()
-
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal(stdlibAddress)
-          this.comparator.reports[0].observed.should.be.equal('none')
-          this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
-        })
-      })
     })
-  })
+  };
 
-  describe('implementations', function () {
-    describe('when the network file does not have any contract', function () {
-      describe('when the directory of the current version does not have any contract', function () {
+  function testProvider () {
+    describe('provider', function () {
+      describe('when the network file shows a different provider address than the one set in the App contract', function () {
+        beforeEach(async function () {
+          await this.app.newVersion('2.0.0')
+          this.networkFile.version = '2.0.0'
+        })
+
+        it('reports that diff', async function () {
+          await this.checker.checkProvider()
+
+          this.comparator.reports.should.have.lengthOf(1)
+          this.comparator.reports[0].expected.should.be.equal(this.networkFile.providerAddress)
+          this.comparator.reports[0].observed.should.be.equal(this.app.currentDirectory().address)
+          this.comparator.reports[0].description.should.be.equal('Provider address does not match')
+        })
+      })
+
+      describe('when the network file provider matches with the one in the App contract', function () {
         it('does not report any diff', async function () {
-          await this.checker.checkImplementations()
+          await this.checker.checkProvider()
 
           this.comparator.reports.should.be.empty
         })
       })
+    })
+  };
 
-      describe('when the directory of the current version has one contract', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+  function testStdlib () {
+    describe('stdlib', function () {
+      describe('when the network file does not specify any stdlib', function () {
+        describe('when the App contract has a stdlib set', function () {
+          beforeEach(async function () {
+            await this.app.setStdlib(anotherAddress)
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkStdlib()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal('none')
+            this.comparator.reports[0].observed.should.be.equal(anotherAddress)
+            this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
+          })
         })
+        
+        describe('when the App contract does not have a stdlib set', function () {
+          it('does not report any diff', async function () {
+            await this.checker.checkStdlib()
 
-        it('reports that diff', async function () {
-          await this.checker.checkImplementations()
-
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal('one')
-          this.comparator.reports[0].description.should.be.equal(`Missing registered contract Impl at ${this.impl.address}`)
-        })
-      })
-
-      describe('when the directory of the current version has many contracts', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          this.impl = await this.app.setImplementation(ImplV1, 'Impl')
-          this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImpl')
-        })
-
-        it('reports one diff per contract', async function () {
-          await this.checker.checkImplementations()
-
-          this.comparator.reports.should.have.lengthOf(2)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal('one')
-          this.comparator.reports[0].description.should.be.equal(`Missing registered contract Impl at ${this.impl.address}`)
-          this.comparator.reports[1].expected.should.be.equal('none')
-          this.comparator.reports[1].observed.should.be.equal('one')
-          this.comparator.reports[1].description.should.be.equal(`Missing registered contract AnotherImpl at ${this.anotherImpl.address}`)
+            this.comparator.reports.should.be.empty
+          })
         })
       })
 
-      describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          await this.app.setImplementation(ImplV1, 'Impl')
-          await this.app.unsetImplementation('Impl', txParams)
-          this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImpl')
+      describe('when the network file has a stdlib', function () {
+        const stdlibAddress = '0x0000000000000000000000000000000000000010'
+
+        beforeEach('set stdlib in network file', async function () {
+          await linkStdlib({stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile})
+          await push({ network, txParams, networkFile: this.networkFile })
         })
 
-        it('reports one diff per contract', async function () {
-          await this.checker.checkImplementations()
+        describe('when the App contract has the same stdlib set', function () {
+          beforeEach('set stdlib in App contract', async function () {
+            await this.app.setStdlib(stdlibAddress)
+          })
 
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal('one')
-          this.comparator.reports[0].description.should.be.equal(`Missing registered contract AnotherImpl at ${this.anotherImpl.address}`)
+          it('does not report any diff', async function () {
+            await this.checker.checkStdlib()
+
+            this.comparator.reports.should.be.empty
+          })
+        })
+
+        describe('when the App contract has another stdlib set', function () {
+          beforeEach('set stdlib in App contract', async function () {
+            await this.app.setStdlib(anotherAddress)
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkStdlib()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal(stdlibAddress)
+            this.comparator.reports[0].observed.should.be.equal(anotherAddress)
+            this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
+          })
+        })
+
+        describe('when the App contract has no stdlib set', function () {
+          beforeEach('unset App stdlib', async function () {
+            await this.app.setStdlib(0x0)
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkStdlib()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal(stdlibAddress)
+            this.comparator.reports[0].observed.should.be.equal('none')
+            this.comparator.reports[0].description.should.be.equal('Stdlib address does not match')
+          })
         })
       })
     })
+  };
 
-    describe('when the network file has some contracts', function () {
+  function testImplementations () {
+    describe('implementations', function () {
+      describe('when the network file does not have any contract', function () {
+        describe('when the directory of the current version does not have any contract', function () {
+          it('does not report any diff', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.be.empty
+          })
+        })
+
+        describe('when the directory of the current version has one contract', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal('none')
+            this.comparator.reports[0].observed.should.be.equal('one')
+            this.comparator.reports[0].description.should.be.equal(`Missing registered contract Impl at ${this.impl.address}`)
+          })
+        })
+
+        describe('when the directory of the current version has many contracts', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImpl')
+          })
+
+          it('reports one diff per contract', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.have.lengthOf(2)
+            this.comparator.reports[0].expected.should.be.equal('none')
+            this.comparator.reports[0].observed.should.be.equal('one')
+            this.comparator.reports[0].description.should.be.equal(`Missing registered contract Impl at ${this.impl.address}`)
+            this.comparator.reports[1].expected.should.be.equal('none')
+            this.comparator.reports[1].observed.should.be.equal('one')
+            this.comparator.reports[1].description.should.be.equal(`Missing registered contract AnotherImpl at ${this.anotherImpl.address}`)
+          })
+        })
+
+        describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            await this.app.setImplementation(ImplV1, 'Impl')
+            await this.app.unsetImplementation('Impl', txParams)
+            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImpl')
+          })
+
+          it('reports one diff per contract', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal('none')
+            this.comparator.reports[0].observed.should.be.equal('one')
+            this.comparator.reports[0].description.should.be.equal(`Missing registered contract AnotherImpl at ${this.anotherImpl.address}`)
+          })
+        })
+      })
+
+      describe('when the network file has some contracts', function () {
+        beforeEach('adding some contracts', async function () {
+          this.impl = await ImplV1.new()
+          this.anotherImpl = await AnotherImplV1.new()
+
+          this.networkFile.addContract('Impl', this.impl)
+          this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+        })
+
+        describe('when the directory of the current version does not have any contract', function () {
+          it('reports that diff', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.have.lengthOf(2)
+            this.comparator.reports[0].expected.should.be.equal('one')
+            this.comparator.reports[0].observed.should.be.equal('none')
+            this.comparator.reports[0].description.should.be.equal(`A contract Impl at ${this.impl.address} is not registered`)
+            this.comparator.reports[1].expected.should.be.equal('one')
+            this.comparator.reports[1].observed.should.be.equal('none')
+            this.comparator.reports[1].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
+          })
+        })
+
+        describe('when the directory of the current version has one of those contract', function () {
+          describe('when the directory has the same address and same bytecode for that contract', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            })
+
+            it('reports only the missing contract', async function () {
+              await this.checker.checkImplementations()
+
+              this.comparator.reports.should.have.lengthOf(1)
+              this.comparator.reports[0].expected.should.be.equal('one')
+              this.comparator.reports[0].observed.should.be.equal('none')
+              this.comparator.reports[0].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
+            })
+          })
+
+          describe('when the directory has another address for that contract', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              await this.app.currentDirectory().setImplementation('Impl', this.anotherImpl.address, txParams)
+            })
+
+            it('reports those diffs', async function () {
+              await this.checker.checkImplementations()
+
+              this.comparator.reports.should.have.lengthOf(3)
+              this.comparator.reports[0].expected.should.be.equal(this.impl.address)
+              this.comparator.reports[0].observed.should.be.equal(this.anotherImpl.address)
+              this.comparator.reports[0].description.should.be.equal('Address for contract Impl does not match')
+              this.comparator.reports[1].expected.should.be.equal(bytecodeDigest(ImplV1.deployedBytecode))
+              this.comparator.reports[1].observed.should.be.equal(bytecodeDigest(AnotherImplV1.deployedBytecode))
+              this.comparator.reports[1].description.should.be.equal(`Bytecode at ${this.anotherImpl.address} for contract Impl does not match`)
+              this.comparator.reports[2].expected.should.be.equal('one')
+              this.comparator.reports[2].observed.should.be.equal('none')
+              this.comparator.reports[2].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
+            })
+          })
+
+          describe('when the bytecode for that contract is different', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              const contracts = this.networkFile.contracts
+              contracts.Impl.bodyBytecodeHash = '0x0'
+              this.networkFile.contracts = contracts
+              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            })
+
+            it('reports both diffs', async function () {
+              await this.checker.checkImplementations()
+
+              this.comparator.reports.should.have.lengthOf(2)
+              this.comparator.reports[0].expected.should.be.equal('0x0')
+              this.comparator.reports[0].observed.should.be.equal(bytecodeDigest(ImplV1.deployedBytecode))
+              this.comparator.reports[0].description.should.be.equal(`Bytecode at ${this.impl.address} for contract Impl does not match`)
+              this.comparator.reports[1].expected.should.be.equal('one')
+              this.comparator.reports[1].observed.should.be.equal('none')
+              this.comparator.reports[1].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
+            })
+          })
+        })
+
+        describe('when the directory of the current version has both contracts', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+          })
+
+          it('does not report any diff ', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.be.empty
+          })
+        })
+
+        describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            await this.app.unsetImplementation('Impl', txParams)
+            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+          })
+
+          it('reports one diff per contract', async function () {
+            await this.checker.checkImplementations()
+
+            this.comparator.reports.should.have.lengthOf(1)
+            this.comparator.reports[0].expected.should.be.equal('one')
+            this.comparator.reports[0].observed.should.be.equal('none')
+            this.comparator.reports[0].description.should.be.equal(`A contract Impl at ${this.impl.address} is not registered`)
+          })
+        })
+      })
+    })
+  };
+
+  function testProxies () {
+    describe('proxies', function () {
       beforeEach('adding some contracts', async function () {
         this.impl = await ImplV1.new()
         this.anotherImpl = await AnotherImplV1.new()
 
         this.networkFile.addContract('Impl', this.impl)
         this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+
+        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+        await this.app.currentDirectory().unsetImplementation('Impl', txParams)
+        await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
       })
 
-      describe('when the directory of the current version does not have any contract', function () {
-        it('reports that diff', async function () {
-          await this.checker.checkImplementations()
-
-          this.comparator.reports.should.have.lengthOf(2)
-          this.comparator.reports[0].expected.should.be.equal('one')
-          this.comparator.reports[0].observed.should.be.equal('none')
-          this.comparator.reports[0].description.should.be.equal(`A contract Impl at ${this.impl.address} is not registered`)
-          this.comparator.reports[1].expected.should.be.equal('one')
-          this.comparator.reports[1].observed.should.be.equal('none')
-          this.comparator.reports[1].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
-        })
-      })
-
-      describe('when the directory of the current version has one of those contract', function () {
-        describe('when the directory has the same address and same bytecode for that contract', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          })
-
-          it('reports only the missing contract', async function () {
-            await this.checker.checkImplementations()
-
-            this.comparator.reports.should.have.lengthOf(1)
-            this.comparator.reports[0].expected.should.be.equal('one')
-            this.comparator.reports[0].observed.should.be.equal('none')
-            this.comparator.reports[0].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
-          })
-        })
-
-        describe('when the directory has another address for that contract', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.anotherImpl.address, txParams)
-          })
-
-          it('reports those diffs', async function () {
-            await this.checker.checkImplementations()
-
-            this.comparator.reports.should.have.lengthOf(3)
-            this.comparator.reports[0].expected.should.be.equal(this.impl.address)
-            this.comparator.reports[0].observed.should.be.equal(this.anotherImpl.address)
-            this.comparator.reports[0].description.should.be.equal('Address for contract Impl does not match')
-            this.comparator.reports[1].expected.should.be.equal(bytecodeDigest(ImplV1.deployedBytecode))
-            this.comparator.reports[1].observed.should.be.equal(bytecodeDigest(AnotherImplV1.deployedBytecode))
-            this.comparator.reports[1].description.should.be.equal(`Bytecode at ${this.anotherImpl.address} for contract Impl does not match`)
-            this.comparator.reports[2].expected.should.be.equal('one')
-            this.comparator.reports[2].observed.should.be.equal('none')
-            this.comparator.reports[2].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
-          })
-        })
-
-        describe('when the bytecode for that contract is different', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            const contracts = this.networkFile.contracts
-            contracts.Impl.bodyBytecodeHash = '0x0'
-            this.networkFile.contracts = contracts
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          })
-
-          it('reports both diffs', async function () {
-            await this.checker.checkImplementations()
-
-            this.comparator.reports.should.have.lengthOf(2)
-            this.comparator.reports[0].expected.should.be.equal('0x0')
-            this.comparator.reports[0].observed.should.be.equal(bytecodeDigest(ImplV1.deployedBytecode))
-            this.comparator.reports[0].description.should.be.equal(`Bytecode at ${this.impl.address} for contract Impl does not match`)
-            this.comparator.reports[1].expected.should.be.equal('one')
-            this.comparator.reports[1].observed.should.be.equal('none')
-            this.comparator.reports[1].description.should.be.equal(`A contract AnotherImpl at ${this.anotherImpl.address} is not registered`)
-          })
-        })
-      })
-
-      describe('when the directory of the current version has both contracts', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-        })
-
-        it('does not report any diff ', async function () {
-          await this.checker.checkImplementations()
-
-          this.comparator.reports.should.be.empty
-        })
-      })
-
-      describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          await this.app.unsetImplementation('Impl', txParams)
-          await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-        })
-
-        it('reports one diff per contract', async function () {
-          await this.checker.checkImplementations()
-
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal('one')
-          this.comparator.reports[0].observed.should.be.equal('none')
-          this.comparator.reports[0].description.should.be.equal(`A contract Impl at ${this.impl.address} is not registered`)
-        })
-      })
-    })
-  })
-
-  describe('proxies', function () {
-    beforeEach('adding some contracts', async function () {
-      this.impl = await ImplV1.new()
-      this.anotherImpl = await AnotherImplV1.new()
-
-      this.networkFile.addContract('Impl', this.impl)
-      this.networkFile.addContract('AnotherImpl', this.anotherImpl)
-
-      await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-      await this.app.currentDirectory().unsetImplementation('Impl', txParams)
-      await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-      await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-    })
-
-    describe('when the network file does not have any proxies', function () {
-      describe('when the app does not have any proxy registered', function () {
-        it('does not report any diff', async function () {
-          await this.checker.checkProxies()
-
-          this.comparator.reports.should.be.empty
-        })
-      })
-
-      describe('when the app has one proxy registered', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-        })
-
-        it('reports that diff', async function () {
-          await this.checker.checkProxies()
-
-          this.comparator.reports.should.have.lengthOf(1)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal('one')
-          this.comparator.reports[0].description.should.be.equal(`Missing registered proxy of Impl at ${this.proxy.address} pointing to ${this.impl.address}`)
-        })
-      })
-
-      describe('when the app has many proxies registered', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          this.implProxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-          this.anotherImplProxy = await this.app.createProxy(AnotherImplV1, 'AnotherImpl', 'initialize', [1])
-        })
-
-        it('reports that diff', async function () {
-          await this.checker.checkProxies()
-
-          this.comparator.reports.should.have.lengthOf(2)
-          this.comparator.reports[0].expected.should.be.equal('none')
-          this.comparator.reports[0].observed.should.be.equal('one')
-          this.comparator.reports[0].description.should.be.equal(`Missing registered proxy of Impl at ${this.implProxy.address} pointing to ${this.impl.address}`)
-          this.comparator.reports[1].expected.should.be.equal('none')
-          this.comparator.reports[1].observed.should.be.equal('one')
-          this.comparator.reports[1].description.should.be.equal(`Missing registered proxy of AnotherImpl at ${this.anotherImplProxy.address} pointing to ${this.anotherImpl.address}`)
-        })
-      })
-    })
-
-    describe('when the network file has two proxies', function () {
-      beforeEach('adding a proxy', async function () {
-        this.networkFile.setProxies('Impl', [
-          { implementation: this.impl.address, address: '0x1', version: '1.0' },
-          { implementation: this.impl.address, address: '0x2', version: '1.0' }
-        ])
-      })
-
-      describe('when the app does not have any proxy registered', function () {
-        it('reports those diffs', async function () {
-          await this.checker.checkProxies()
-
-          this.comparator.reports.should.be.have.lengthOf(2)
-          this.comparator.reports[0].expected.should.be.equal('one')
-          this.comparator.reports[0].observed.should.be.equal('none')
-          this.comparator.reports[0].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-          this.comparator.reports[1].expected.should.be.equal('one')
-          this.comparator.reports[1].observed.should.be.equal('none')
-          this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x2 pointing to ${this.impl.address} is not registered`)
-        })
-      })
-
-      describe('when the app has one proxy registered', function () {
-        beforeEach('creating a proxy', async function () {
-          this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-        })
-
-        describe('when it matches one proxy address', function () {
-          describe('when it matches the alias and the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
-              ])
-            })
-
-            it('reports that diff', async function () {
-              await this.checker.checkProxies()
-
-              this.comparator.reports.should.have.lengthOf(1)
-              this.comparator.reports[0].expected.should.be.equal('one')
-              this.comparator.reports[0].observed.should.be.equal('none')
-              this.comparator.reports[0].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-            })
-          })
-
-          describe('when it matches the alias but not the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
-              ])
-            })
-
-            it('reports that diff', async function () {
-              await this.checker.checkProxies()
-
-              this.comparator.reports.should.have.lengthOf(2)
-              this.comparator.reports[0].expected.should.be.equal(this.anotherImpl.address)
-              this.comparator.reports[0].observed.should.be.equal(this.impl.address)
-              this.comparator.reports[0].description.should.be.equal(`Pointed implementation of Impl proxy at ${this.proxy.address} does not match`)
-              this.comparator.reports[1].expected.should.be.equal('one')
-              this.comparator.reports[1].observed.should.be.equal('none')
-              this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-            })
-          })
-
-          describe('when it matches the implementation address but not the alias', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
-            })
-
-            it('reports that diff', async function () {
-              await this.checker.checkProxies()
-
-              this.comparator.reports.should.have.lengthOf(2)
-              this.comparator.reports[0].expected.should.be.equal('AnotherImpl')
-              this.comparator.reports[0].observed.should.be.equal('Impl')
-              this.comparator.reports[0].description.should.be.equal(`Alias of proxy at ${this.proxy.address} pointing to ${this.impl.address} does not match`)
-              this.comparator.reports[1].expected.should.be.equal('one')
-              this.comparator.reports[1].observed.should.be.equal('none')
-              this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-            })
-          })
-
-          describe('when it does not match the alias and the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
-            })
-
-            it('reports that diff', async function () {
-              await this.checker.checkProxies()
-
-              this.comparator.reports.should.have.lengthOf(3)
-              this.comparator.reports[0].expected.should.be.equal('AnotherImpl')
-              this.comparator.reports[0].observed.should.be.equal('Impl')
-              this.comparator.reports[0].description.should.be.equal(`Alias of proxy at ${this.proxy.address} pointing to ${this.impl.address} does not match`)
-              this.comparator.reports[1].expected.should.be.equal(this.anotherImpl.address)
-              this.comparator.reports[1].observed.should.be.equal(this.impl.address)
-              this.comparator.reports[1].description.should.be.equal(`Pointed implementation of Impl proxy at ${this.proxy.address} does not match`)
-              this.comparator.reports[2].expected.should.be.equal('one')
-              this.comparator.reports[2].observed.should.be.equal('none')
-              this.comparator.reports[2].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-            })
-          })
-        })
-
-        describe('when it does not match any proxy address', function () {
-
-          it('reports those diffs', async function () {
+      describe('when the network file does not have any proxies', function () {
+        describe('when the app does not have any proxy registered', function () {
+          it('does not report any diff', async function () {
             await this.checker.checkProxies()
 
-            this.comparator.reports.should.have.lengthOf(3)
+            this.comparator.reports.should.be.empty
+          })
+        })
+
+        describe('when the app has one proxy registered', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkProxies()
+
+            this.comparator.reports.should.have.lengthOf(1)
             this.comparator.reports[0].expected.should.be.equal('none')
             this.comparator.reports[0].observed.should.be.equal('one')
             this.comparator.reports[0].description.should.be.equal(`Missing registered proxy of Impl at ${this.proxy.address} pointing to ${this.impl.address}`)
+          })
+        })
+
+        describe('when the app has many proxies registered', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            this.implProxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+            this.anotherImplProxy = await this.app.createProxy(AnotherImplV1, 'AnotherImpl', 'initialize', [1])
+          })
+
+          it('reports that diff', async function () {
+            await this.checker.checkProxies()
+
+            this.comparator.reports.should.have.lengthOf(2)
+            this.comparator.reports[0].expected.should.be.equal('none')
+            this.comparator.reports[0].observed.should.be.equal('one')
+            this.comparator.reports[0].description.should.be.equal(`Missing registered proxy of Impl at ${this.implProxy.address} pointing to ${this.impl.address}`)
+            this.comparator.reports[1].expected.should.be.equal('none')
+            this.comparator.reports[1].observed.should.be.equal('one')
+            this.comparator.reports[1].description.should.be.equal(`Missing registered proxy of AnotherImpl at ${this.anotherImplProxy.address} pointing to ${this.anotherImpl.address}`)
+          })
+        })
+      })
+
+      describe('when the network file has two proxies', function () {
+        beforeEach('adding a proxy', async function () {
+          this.networkFile.setProxies('Impl', [
+            { implementation: this.impl.address, address: '0x1', version: '1.0' },
+            { implementation: this.impl.address, address: '0x2', version: '1.0' }
+          ])
+        })
+
+        describe('when the app does not have any proxy registered', function () {
+          it('reports those diffs', async function () {
+            await this.checker.checkProxies()
+
+            this.comparator.reports.should.be.have.lengthOf(2)
+            this.comparator.reports[0].expected.should.be.equal('one')
+            this.comparator.reports[0].observed.should.be.equal('none')
+            this.comparator.reports[0].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
             this.comparator.reports[1].expected.should.be.equal('one')
             this.comparator.reports[1].observed.should.be.equal('none')
-            this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
-            this.comparator.reports[2].expected.should.be.equal('one')
-            this.comparator.reports[2].observed.should.be.equal('none')
-            this.comparator.reports[2].description.should.be.equal(`A proxy of Impl at 0x2 pointing to ${this.impl.address} is not registered`)
+            this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x2 pointing to ${this.impl.address} is not registered`)
+          })
+        })
+
+        describe('when the app has one proxy registered', function () {
+          beforeEach('creating a proxy', async function () {
+            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+          })
+
+          describe('when it matches one proxy address', function () {
+            describe('when it matches the alias and the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
+                  { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
+                ])
+              })
+
+              it('reports that diff', async function () {
+                await this.checker.checkProxies()
+
+                this.comparator.reports.should.have.lengthOf(1)
+                this.comparator.reports[0].expected.should.be.equal('one')
+                this.comparator.reports[0].observed.should.be.equal('none')
+                this.comparator.reports[0].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
+              })
+            })
+
+            describe('when it matches the alias but not the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
+                  { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
+                ])
+              })
+
+              it('reports that diff', async function () {
+                await this.checker.checkProxies()
+
+                this.comparator.reports.should.have.lengthOf(2)
+                this.comparator.reports[0].expected.should.be.equal(this.anotherImpl.address)
+                this.comparator.reports[0].observed.should.be.equal(this.impl.address)
+                this.comparator.reports[0].description.should.be.equal(`Pointed implementation of Impl proxy at ${this.proxy.address} does not match`)
+                this.comparator.reports[1].expected.should.be.equal('one')
+                this.comparator.reports[1].observed.should.be.equal('none')
+                this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
+              })
+            })
+
+            describe('when it matches the implementation address but not the alias', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
+                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
+              })
+
+              it('reports that diff', async function () {
+                await this.checker.checkProxies()
+
+                this.comparator.reports.should.have.lengthOf(2)
+                this.comparator.reports[0].expected.should.be.equal('AnotherImpl')
+                this.comparator.reports[0].observed.should.be.equal('Impl')
+                this.comparator.reports[0].description.should.be.equal(`Alias of proxy at ${this.proxy.address} pointing to ${this.impl.address} does not match`)
+                this.comparator.reports[1].expected.should.be.equal('one')
+                this.comparator.reports[1].observed.should.be.equal('none')
+                this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
+              })
+            })
+
+            describe('when it does not match the alias and the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
+                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
+              })
+
+              it('reports that diff', async function () {
+                await this.checker.checkProxies()
+
+                this.comparator.reports.should.have.lengthOf(3)
+                this.comparator.reports[0].expected.should.be.equal('AnotherImpl')
+                this.comparator.reports[0].observed.should.be.equal('Impl')
+                this.comparator.reports[0].description.should.be.equal(`Alias of proxy at ${this.proxy.address} pointing to ${this.impl.address} does not match`)
+                this.comparator.reports[1].expected.should.be.equal(this.anotherImpl.address)
+                this.comparator.reports[1].observed.should.be.equal(this.impl.address)
+                this.comparator.reports[1].description.should.be.equal(`Pointed implementation of Impl proxy at ${this.proxy.address} does not match`)
+                this.comparator.reports[2].expected.should.be.equal('one')
+                this.comparator.reports[2].observed.should.be.equal('none')
+                this.comparator.reports[2].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
+              })
+            })
+          })
+
+          describe('when it does not match any proxy address', function () {
+
+            it('reports those diffs', async function () {
+              await this.checker.checkProxies()
+
+              this.comparator.reports.should.have.lengthOf(3)
+              this.comparator.reports[0].expected.should.be.equal('none')
+              this.comparator.reports[0].observed.should.be.equal('one')
+              this.comparator.reports[0].description.should.be.equal(`Missing registered proxy of Impl at ${this.proxy.address} pointing to ${this.impl.address}`)
+              this.comparator.reports[1].expected.should.be.equal('one')
+              this.comparator.reports[1].observed.should.be.equal('none')
+              this.comparator.reports[1].description.should.be.equal(`A proxy of Impl at 0x1 pointing to ${this.impl.address} is not registered`)
+              this.comparator.reports[2].expected.should.be.equal('one')
+              this.comparator.reports[2].observed.should.be.equal('none')
+              this.comparator.reports[2].description.should.be.equal(`A proxy of Impl at 0x2 pointing to ${this.impl.address} is not registered`)
+            })
           })
         })
       })
     })
-  })
+  };
 })

--- a/test/models/StatusFetcher.test.js
+++ b/test/models/StatusFetcher.test.js
@@ -9,6 +9,7 @@ import StatusChecker from '../../src/models/status/StatusChecker'
 import StatusFetcher from '../../src/models/status/StatusFetcher'
 import ZosPackageFile from '../../src/models/files/ZosPackageFile'
 import {bodyCode, bytecodeDigest, constructorCode} from '../../src/utils/contracts'
+import PackageAtVersion from '../../src/models/lib/PackageAtVersion';
 
 const ImplV1 = Contracts.getFromLocal('ImplV1')
 const AnotherImplV1 = Contracts.getFromLocal('AnotherImplV1')
@@ -17,516 +18,432 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
   const network = 'test'
   const txParams = { from: owner }
 
-  beforeEach('initializing network file and status checker', async function () {
-    this.packageFile = new ZosPackageFile('test/mocks/packages/package-empty.zos.json')
+  describe('app', function () {
+    beforeEach('initializing network file and status checker', async function () {
+      init.call(this, 'test/mocks/packages/package-empty.zos.json');
+    })
+  
+    beforeEach('deploying an app', async function () {
+      await push({ network, txParams, networkFile: this.networkFile })
+      this.app = await App.fetch(this.networkFile.appAddress, txParams)
+    })
+
+    testVersion();
+    testImplementations();
+    testPackage();
+    testProvider();
+    testProxies();
+    testStdlib();
+  });
+
+  describe('lib', function () {
+    beforeEach('initializing network file and status checker', async function () {
+      init.call(this, 'test/mocks/packages/package-empty-lib.zos.json');
+    })
+  
+    beforeEach('deploying a lib', async function () {
+      await push({ network, txParams, networkFile: this.networkFile })
+      this.app = await PackageAtVersion.fetch(this.networkFile.packageAddress, "1.1.0", txParams)
+    })
+
+    testImplementations();
+    testProvider();
+  });
+
+  function init(fileName) {
+    this.packageFile = new ZosPackageFile(fileName)
     this.networkFile = this.packageFile.networkFile(network)
     this.fetcher = new StatusFetcher(this.networkFile)
     this.checker = new StatusChecker(this.fetcher, this.networkFile, txParams)
-  })
+  }
 
-  beforeEach('deploying an app', async function () {
-    await push({ network, txParams, networkFile: this.networkFile })
-    this.app = await App.fetch(this.networkFile.appAddress, txParams)
-  })
+  function testVersion () {
+    describe('version', function () {
+      describe('when the network file shows a different version than the one set in the App contract', function () {
+        const newVersion = '2.0.0'
 
-  describe('version', function () {
-    describe('when the network file shows a different version than the one set in the App contract', function () {
-      const newVersion = '2.0.0'
-
-      beforeEach(async function () {
-        await this.app.newVersion(newVersion)
-      })
-
-      it('updates the version', async function () {
-        await this.checker.checkVersion()
-
-        this.networkFile.version.should.be.equal('2.0.0')
-      })
-    })
-
-    describe('when the network file version matches with the one in the App contract', function () {
-      it('should not change the version', async function () {
-        const previousVersion = this.networkFile.version
-
-        await this.checker.checkVersion()
-
-        this.networkFile.version.should.be.equal(previousVersion)
-      })
-    })
-  })
-
-  describe('package', function () {
-    describe('when the network file shows a different package address than the one set in the App contract', function () {
-      beforeEach(async function () {
-        this.networkFile.package = { address: '0x1' }
-      })
-
-      it('updates the package address', async function () {
-        await this.checker.checkPackage()
-
-        this.networkFile.packageAddress.should.have.be.equal(this.app.package.address)
-      })
-    })
-
-    describe('when the network file package matches with the one in the App contract', function () {
-      it('does not update the package address', async function () {
-        const previousPackage = this.networkFile.packageAddress
-
-        await this.checker.checkPackage()
-
-        this.networkFile.packageAddress.should.be.equal(previousPackage)
-      })
-    })
-  })
-
-  describe('provider', function () {
-    describe('when the network file shows a different provider address than the one set in the App contract', function () {
-      beforeEach(async function () {
-        await this.app.newVersion('2.0.0')
-      })
-
-      it('updates the provider address', async function () {
-        await this.checker.checkProvider()
-
-        this.networkFile.providerAddress.should.have.be.equal(this.app.currentDirectory().address)
-      })
-    })
-
-    describe('when the network file provider matches with the one in the App contract', function () {
-      it('does not update the provider address', async function () {
-        const previousProvider = this.networkFile.providerAddress
-
-        await this.checker.checkProvider()
-
-        this.networkFile.providerAddress.should.be.equal(previousProvider)
-      })
-    })
-  })
-
-  describe('stdlib', function () {
-    describe('when the network file does not specify any stdlib', function () {
-      describe('when the App contract has a stdlib set', function () {
         beforeEach(async function () {
-          await this.app.setStdlib(anotherAddress)
+          await this.app.newVersion(newVersion)
         })
 
-        it('updates the address of the stdlib', async function () {
-          await this.checker.checkStdlib()
+        it('updates the version', async function () {
+          await this.checker.checkVersion()
 
-          this.networkFile.stdlibAddress.should.be.equal(anotherAddress)
-        })
-      })
-      
-      describe('when the App contract does not have a stdlib set', function () {
-        it('does not update the address of the stdlib', async function () {
-          await this.checker.checkStdlib()
-
-          this.networkFile.stdlib.should.be.empty
-        })
-      })
-    })
-
-    describe('when the network file has a stdlib', function () {
-      const stdlibAddress = '0x0000000000000000000000000000000000000010'
-
-      beforeEach('set stdlib in network file', async function () {
-        await linkStdlib({stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile})
-        await push({ network, txParams, networkFile: this.networkFile })
-      })
-
-      describe('when the App contract has the same stdlib set', function () {
-        beforeEach('set stdlib in App contract', async function () {
-          await this.app.setStdlib(stdlibAddress)
-        })
-
-        it('does not update the address of the stdlib', async function () {
-          const previousAddress = this.networkFile.stdlibAddress
-
-          await this.checker.checkStdlib()
-
-          this.networkFile.stdlibAddress.should.be.equal(previousAddress)
+          this.networkFile.version.should.be.equal('2.0.0')
         })
       })
 
-      describe('when the App contract has another stdlib set', function () {
-        beforeEach('set stdlib in App contract', async function () {
-          await this.app.setStdlib(anotherAddress)
-        })
+      describe('when the network file version matches with the one in the App contract', function () {
+        it('should not change the version', async function () {
+          const previousVersion = this.networkFile.version
 
-        it('updates the address of the stdlib', async function () {
-          await this.checker.checkStdlib()
+          await this.checker.checkVersion()
 
-          this.networkFile.stdlibAddress.should.be.equal(anotherAddress)
-        })
-      })
-
-      describe('when the App contract has no stdlib set', function () {
-        beforeEach('unset App stdlib', async function () {
-          await this.app.setStdlib(0x0)
-        })
-
-        it('deletes the stdlib', async function () {
-          await this.checker.checkStdlib()
-
-          this.networkFile.stdlib.should.be.empty
+          this.networkFile.version.should.be.equal(previousVersion)
         })
       })
     })
-  })
+  };
 
-  describe('implementations', function () {
-    describe('when the network file does not have any contract', function () {
-      describe('when the directory of the current version does not have any contract', function () {
-        it('does not update the contracts list', async function () {
-          await this.checker.checkImplementations()
+  function testPackage () {
+    describe('package', function () {
+      describe('when the network file shows a different package address than the one set in the App contract', function () {
+        beforeEach(async function () {
+          this.networkFile.package = { address: '0x1' }
+        })
 
-          this.networkFile.contracts.should.be.empty
+        it('updates the package address', async function () {
+          await this.checker.checkPackage()
+
+          this.networkFile.packageAddress.should.have.be.equal(this.app.package.address)
         })
       })
 
-      describe('when the directory of the current version has one contract', function () {
-        describe('when the contract alias and contract name are the same', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
+      describe('when the network file package matches with the one in the App contract', function () {
+        it('does not update the package address', async function () {
+          const previousPackage = this.networkFile.packageAddress
+
+          await this.checker.checkPackage()
+
+          this.networkFile.packageAddress.should.be.equal(previousPackage)
+        })
+      })
+    })
+  };
+
+  function testProvider () {
+    describe('provider', function () {
+      describe('when the network file shows a different provider address than the one set in the App contract', function () {
+        beforeEach(async function () {
+          await this.app.newVersion('2.0.0')
+          this.networkFile.version = '2.0.0'
+        })
+
+        it('updates the provider address', async function () {
+          await this.checker.checkProvider()
+
+          this.networkFile.providerAddress.should.have.be.equal(this.app.currentDirectory().address)
+        })
+      })
+
+      describe('when the network file provider matches with the one in the App contract', function () {
+        it('does not update the provider address', async function () {
+          const previousProvider = this.networkFile.providerAddress
+
+          await this.checker.checkProvider()
+
+          this.networkFile.providerAddress.should.be.equal(previousProvider)
+        })
+      })
+    })
+  };
+
+  function testStdlib () {
+    describe('stdlib', function () {
+      describe('when the network file does not specify any stdlib', function () {
+        describe('when the App contract has a stdlib set', function () {
+          beforeEach(async function () {
+            await this.app.setStdlib(anotherAddress)
           })
 
-          it('adds that contract', async function () {
+          it('updates the address of the stdlib', async function () {
+            await this.checker.checkStdlib()
+
+            this.networkFile.stdlibAddress.should.be.equal(anotherAddress)
+          })
+        })
+        
+        describe('when the App contract does not have a stdlib set', function () {
+          it('does not update the address of the stdlib', async function () {
+            await this.checker.checkStdlib()
+
+            this.networkFile.stdlib.should.be.empty
+          })
+        })
+      })
+
+      describe('when the network file has a stdlib', function () {
+        const stdlibAddress = '0x0000000000000000000000000000000000000010'
+
+        beforeEach('set stdlib in network file', async function () {
+          await linkStdlib({stdlibNameVersion: 'mock-stdlib@1.1.0', packageFile: this.packageFile})
+          await push({ network, txParams, networkFile: this.networkFile })
+        })
+
+        describe('when the App contract has the same stdlib set', function () {
+          beforeEach('set stdlib in App contract', async function () {
+            await this.app.setStdlib(stdlibAddress)
+          })
+
+          it('does not update the address of the stdlib', async function () {
+            const previousAddress = this.networkFile.stdlibAddress
+
+            await this.checker.checkStdlib()
+
+            this.networkFile.stdlibAddress.should.be.equal(previousAddress)
+          })
+        })
+
+        describe('when the App contract has another stdlib set', function () {
+          beforeEach('set stdlib in App contract', async function () {
+            await this.app.setStdlib(anotherAddress)
+          })
+
+          it('updates the address of the stdlib', async function () {
+            await this.checker.checkStdlib()
+
+            this.networkFile.stdlibAddress.should.be.equal(anotherAddress)
+          })
+        })
+
+        describe('when the App contract has no stdlib set', function () {
+          beforeEach('unset App stdlib', async function () {
+            await this.app.setStdlib(0x0)
+          })
+
+          it('deletes the stdlib', async function () {
+            await this.checker.checkStdlib()
+
+            this.networkFile.stdlib.should.be.empty
+          })
+        })
+      })
+    })
+  };
+
+  function testImplementations () {
+    describe('implementations', function () {
+      describe('when the network file does not have any contract', function () {
+        describe('when the directory of the current version does not have any contract', function () {
+          it('does not update the contracts list', async function () {
             await this.checker.checkImplementations()
 
-            this.networkFile.contractAliases.should.have.lengthOf(1)
+            this.networkFile.contracts.should.be.empty
+          })
+        })
+
+        describe('when the directory of the current version has one contract', function () {
+          describe('when the contract alias and contract name are the same', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
+            })
+
+            it('adds that contract', async function () {
+              await this.checker.checkImplementations()
+
+              this.networkFile.contractAliases.should.have.lengthOf(1)
+              this.networkFile.contract('ImplV1').address.should.be.equal(this.impl.address)
+              this.networkFile.contract('ImplV1').bytecodeHash.should.be.equal(bytecodeDigest(ImplV1.bytecode))
+              this.networkFile.contract('ImplV1').constructorCode.should.be.equal(constructorCode(this.impl))
+              this.networkFile.contract('ImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
+            })
+          })
+
+          describe('when the contract alias and contract name are different', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+            })
+
+            it('adds that contract', async function () {
+              await this.checker.checkImplementations()
+
+              this.networkFile.contractAliases.should.have.lengthOf(1)
+              this.networkFile.contract('Impl').address.should.be.equal(this.impl.address)
+              this.networkFile.contract('Impl').bytecodeHash.should.be.equal('unknown')
+              this.networkFile.contract('Impl').constructorCode.should.be.equal('unknown')
+              this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
+            })
+          })
+        })
+
+        describe('when the directory of the current version has many contracts', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
+            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
+          })
+
+          it('adds those contracts', async function () {
+            await this.checker.checkImplementations()
+
+            this.networkFile.contractAliases.should.have.lengthOf(2)
             this.networkFile.contract('ImplV1').address.should.be.equal(this.impl.address)
             this.networkFile.contract('ImplV1').bytecodeHash.should.be.equal(bytecodeDigest(ImplV1.bytecode))
             this.networkFile.contract('ImplV1').constructorCode.should.be.equal(constructorCode(this.impl))
             this.networkFile.contract('ImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
+            this.networkFile.contract('AnotherImplV1').address.should.be.equal(this.anotherImpl.address)
+            this.networkFile.contract('AnotherImplV1').bytecodeHash.should.be.equal(bytecodeDigest(AnotherImplV1.bytecode))
+            this.networkFile.contract('AnotherImplV1').constructorCode.should.be.equal(constructorCode(this.anotherImpl))
+            this.networkFile.contract('AnotherImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.anotherImpl)))
           })
         })
 
-        describe('when the contract alias and contract name are different', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            this.impl = await this.app.setImplementation(ImplV1, 'Impl')
+        describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            await this.app.setImplementation(ImplV1, 'Impl')
+            await this.app.unsetImplementation('Impl', txParams)
+            this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
           })
 
-          it('adds that contract', async function () {
+          it('reports one diff per contract', async function () {
             await this.checker.checkImplementations()
 
             this.networkFile.contractAliases.should.have.lengthOf(1)
-            this.networkFile.contract('Impl').address.should.be.equal(this.impl.address)
-            this.networkFile.contract('Impl').bytecodeHash.should.be.equal('unknown')
-            this.networkFile.contract('Impl').constructorCode.should.be.equal('unknown')
-            this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
+            this.networkFile.contract('AnotherImplV1').address.should.be.equal(this.anotherImpl.address)
+            this.networkFile.contract('AnotherImplV1').bytecodeHash.should.be.equal(bytecodeDigest(AnotherImplV1.bytecode))
+            this.networkFile.contract('AnotherImplV1').constructorCode.should.be.equal(constructorCode(this.anotherImpl))
+            this.networkFile.contract('AnotherImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.anotherImpl)))
           })
         })
       })
 
-      describe('when the directory of the current version has many contracts', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          this.impl = await this.app.setImplementation(ImplV1, 'ImplV1')
-          this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
+      describe('when the network file has some contracts', function () {
+        beforeEach('adding some contracts', async function () {
+          this.impl = await ImplV1.new()
+          this.anotherImpl = await AnotherImplV1.new()
+
+          this.networkFile.addContract('Impl', this.impl)
+          this.networkFile.addContract('AnotherImpl', this.anotherImpl)
         })
 
-        it('adds those contracts', async function () {
-          await this.checker.checkImplementations()
+        describe('when the directory of the current version does not have any contract', function () {
+          it('removes those contracts', async function () {
+            await this.checker.checkImplementations()
 
-          this.networkFile.contractAliases.should.have.lengthOf(2)
-          this.networkFile.contract('ImplV1').address.should.be.equal(this.impl.address)
-          this.networkFile.contract('ImplV1').bytecodeHash.should.be.equal(bytecodeDigest(ImplV1.bytecode))
-          this.networkFile.contract('ImplV1').constructorCode.should.be.equal(constructorCode(this.impl))
-          this.networkFile.contract('ImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
-          this.networkFile.contract('AnotherImplV1').address.should.be.equal(this.anotherImpl.address)
-          this.networkFile.contract('AnotherImplV1').bytecodeHash.should.be.equal(bytecodeDigest(AnotherImplV1.bytecode))
-          this.networkFile.contract('AnotherImplV1').constructorCode.should.be.equal(constructorCode(this.anotherImpl))
-          this.networkFile.contract('AnotherImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.anotherImpl)))
-        })
-      })
-
-      describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          await this.app.setImplementation(ImplV1, 'Impl')
-          await this.app.unsetImplementation('Impl', txParams)
-          this.anotherImpl = await this.app.setImplementation(AnotherImplV1, 'AnotherImplV1')
+            this.networkFile.contracts.should.be.empty
+          })
         })
 
-        it('reports one diff per contract', async function () {
-          await this.checker.checkImplementations()
+        describe('when the directory of the current version has one of those contract', function () {
+          describe('when the directory has the same address and same bytecode for that contract', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            })
 
-          this.networkFile.contractAliases.should.have.lengthOf(1)
-          this.networkFile.contract('AnotherImplV1').address.should.be.equal(this.anotherImpl.address)
-          this.networkFile.contract('AnotherImplV1').bytecodeHash.should.be.equal(bytecodeDigest(AnotherImplV1.bytecode))
-          this.networkFile.contract('AnotherImplV1').constructorCode.should.be.equal(constructorCode(this.anotherImpl))
-          this.networkFile.contract('AnotherImplV1').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.anotherImpl)))
+            it('removes the unregistered contract without changing the registered one', async function () {
+              const previousContract = this.networkFile.contract('Impl')
+
+              await this.checker.checkImplementations()
+
+              this.networkFile.contractAliases.should.have.lengthOf(1)
+              this.networkFile.contract('Impl').address.should.be.equal(previousContract.address)
+              this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
+              this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
+              this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(previousContract.bodyBytecodeHash)
+            })
+          })
+
+          describe('when the directory has another address for that contract', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              await this.app.currentDirectory().setImplementation('Impl', this.anotherImpl.address, txParams)
+            })
+
+            it('removes the unregistered contract and updates the address of the registered one', async function () {
+              const previousContract = this.networkFile.contract('Impl')
+
+              await this.checker.checkImplementations()
+
+              this.networkFile.contractAliases.should.have.lengthOf(1)
+              this.networkFile.contract('Impl').address.should.be.equal(this.anotherImpl.address)
+              this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
+              this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
+              this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(previousContract.bodyBytecodeHash)
+            })
+          })
+
+          describe('when the bytecode for that contract is different', function () {
+            beforeEach('registering new implementation in AppDirectory', async function () {
+              this.networkFile.setContractBodyBytecodeHash('Impl', '0x0')
+              await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            })
+
+            it('removes the unregistered contract and updates the bytecode of the registered one', async function () {
+              const previousContract = this.networkFile.contract('Impl')
+
+              await this.checker.checkImplementations()
+
+              this.networkFile.contractAliases.should.have.lengthOf(1)
+              this.networkFile.contract('Impl').address.should.be.equal(previousContract.address)
+              this.networkFile.contract('Impl').bytecodeHash.should.be.equal(bytecodeDigest(ImplV1.bytecode))
+              this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
+              this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
+            })
+          })
+        })
+
+        describe('when the directory of the current version has both contracts', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+          })
+
+          it('does not update the contracts list', async function () {
+            const previousImplContract = this.networkFile.contract('Impl')
+            const previousAnotherImplContract = this.networkFile.contract('AnotherImpl')
+
+            await this.checker.checkImplementations()
+
+            this.networkFile.contractAliases.should.have.lengthOf(2)
+            this.networkFile.contract('Impl').address.should.be.equal(previousImplContract.address)
+            this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousImplContract.bytecodeHash)
+            this.networkFile.contract('Impl').constructorCode.should.be.equal(previousImplContract.constructorCode)
+            this.networkFile.contract('AnotherImpl').address.should.be.equal(previousAnotherImplContract.address)
+            this.networkFile.contract('AnotherImpl').bytecodeHash.should.be.equal(previousAnotherImplContract.bytecodeHash)
+            this.networkFile.contract('AnotherImpl').constructorCode.should.be.equal(previousAnotherImplContract.constructorCode)
+          })
+        })
+
+        describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
+          beforeEach('registering two new implementations in AppDirectory', async function () {
+            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            await this.app.unsetImplementation('Impl', txParams)
+            await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+          })
+
+          it('adds the missing contract', async function () {
+            const previousContract = this.networkFile.contract('AnotherImpl')
+
+            await this.checker.checkImplementations()
+
+            this.networkFile.contractAliases.should.have.lengthOf(1)
+            this.networkFile.contract('AnotherImpl').address.should.be.equal(previousContract.address)
+            this.networkFile.contract('AnotherImpl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
+            this.networkFile.contract('AnotherImpl').constructorCode.should.be.equal(previousContract.constructorCode)
+          })
         })
       })
     })
+  };
 
-    describe('when the network file has some contracts', function () {
+  function testProxies () {
+    describe('proxies', function () {
       beforeEach('adding some contracts', async function () {
         this.impl = await ImplV1.new()
         this.anotherImpl = await AnotherImplV1.new()
 
         this.networkFile.addContract('Impl', this.impl)
         this.networkFile.addContract('AnotherImpl', this.anotherImpl)
+
+        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+        await this.app.currentDirectory().unsetImplementation('Impl', txParams)
+        await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
+        await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
       })
 
-      describe('when the directory of the current version does not have any contract', function () {
-        it('removes those contracts', async function () {
-          await this.checker.checkImplementations()
+      describe('when the network file does not have any proxies', function () {
+        describe('when the app does not have any proxy registered', function () {
+          it('does not modoify the proxies list', async function () {
+            await this.checker.checkProxies()
 
-          this.networkFile.contracts.should.be.empty
+            this.networkFile.proxyAliases.should.be.empty
+          })
         })
-      })
 
-      describe('when the directory of the current version has one of those contract', function () {
-        describe('when the directory has the same address and same bytecode for that contract', function () {
+        describe('when the app has one proxy registered', function () {
           beforeEach('registering new implementation in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
+            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
           })
 
-          it('removes the unregistered contract without changing the registered one', async function () {
-            const previousContract = this.networkFile.contract('Impl')
-
-            await this.checker.checkImplementations()
-
-            this.networkFile.contractAliases.should.have.lengthOf(1)
-            this.networkFile.contract('Impl').address.should.be.equal(previousContract.address)
-            this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
-            this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
-            this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(previousContract.bodyBytecodeHash)
-          })
-        })
-
-        describe('when the directory has another address for that contract', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            await this.app.currentDirectory().setImplementation('Impl', this.anotherImpl.address, txParams)
-          })
-
-          it('removes the unregistered contract and updates the address of the registered one', async function () {
-            const previousContract = this.networkFile.contract('Impl')
-
-            await this.checker.checkImplementations()
-
-            this.networkFile.contractAliases.should.have.lengthOf(1)
-            this.networkFile.contract('Impl').address.should.be.equal(this.anotherImpl.address)
-            this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
-            this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
-            this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(previousContract.bodyBytecodeHash)
-          })
-        })
-
-        describe('when the bytecode for that contract is different', function () {
-          beforeEach('registering new implementation in AppDirectory', async function () {
-            this.networkFile.setContractBodyBytecodeHash('Impl', '0x0')
-            await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          })
-
-          it('removes the unregistered contract and updates the bytecode of the registered one', async function () {
-            const previousContract = this.networkFile.contract('Impl')
-
-            await this.checker.checkImplementations()
-
-            this.networkFile.contractAliases.should.have.lengthOf(1)
-            this.networkFile.contract('Impl').address.should.be.equal(previousContract.address)
-            this.networkFile.contract('Impl').bytecodeHash.should.be.equal(bytecodeDigest(ImplV1.bytecode))
-            this.networkFile.contract('Impl').constructorCode.should.be.equal(previousContract.constructorCode)
-            this.networkFile.contract('Impl').bodyBytecodeHash.should.be.equal(bytecodeDigest(bodyCode(this.impl)))
-          })
-        })
-      })
-
-      describe('when the directory of the current version has both contracts', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-        })
-
-        it('does not update the contracts list', async function () {
-          const previousImplContract = this.networkFile.contract('Impl')
-          const previousAnotherImplContract = this.networkFile.contract('AnotherImpl')
-
-          await this.checker.checkImplementations()
-
-          this.networkFile.contractAliases.should.have.lengthOf(2)
-          this.networkFile.contract('Impl').address.should.be.equal(previousImplContract.address)
-          this.networkFile.contract('Impl').bytecodeHash.should.be.equal(previousImplContract.bytecodeHash)
-          this.networkFile.contract('Impl').constructorCode.should.be.equal(previousImplContract.constructorCode)
-          this.networkFile.contract('AnotherImpl').address.should.be.equal(previousAnotherImplContract.address)
-          this.networkFile.contract('AnotherImpl').bytecodeHash.should.be.equal(previousAnotherImplContract.bytecodeHash)
-          this.networkFile.contract('AnotherImpl').constructorCode.should.be.equal(previousAnotherImplContract.constructorCode)
-        })
-      })
-
-      describe('when the directory of the current version has many contracts and some of them where unregistered', function () {
-        beforeEach('registering two new implementations in AppDirectory', async function () {
-          await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-          await this.app.unsetImplementation('Impl', txParams)
-          await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-        })
-
-        it('adds the missing contract', async function () {
-          const previousContract = this.networkFile.contract('AnotherImpl')
-
-          await this.checker.checkImplementations()
-
-          this.networkFile.contractAliases.should.have.lengthOf(1)
-          this.networkFile.contract('AnotherImpl').address.should.be.equal(previousContract.address)
-          this.networkFile.contract('AnotherImpl').bytecodeHash.should.be.equal(previousContract.bytecodeHash)
-          this.networkFile.contract('AnotherImpl').constructorCode.should.be.equal(previousContract.constructorCode)
-        })
-      })
-    })
-  })
-
-  describe('proxies', function () {
-    beforeEach('adding some contracts', async function () {
-      this.impl = await ImplV1.new()
-      this.anotherImpl = await AnotherImplV1.new()
-
-      this.networkFile.addContract('Impl', this.impl)
-      this.networkFile.addContract('AnotherImpl', this.anotherImpl)
-
-      await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-      await this.app.currentDirectory().unsetImplementation('Impl', txParams)
-      await this.app.currentDirectory().setImplementation('AnotherImpl', this.anotherImpl.address, txParams)
-      await this.app.currentDirectory().setImplementation('Impl', this.impl.address, txParams)
-    })
-
-    describe('when the network file does not have any proxies', function () {
-      describe('when the app does not have any proxy registered', function () {
-        it('does not modoify the proxies list', async function () {
-          await this.checker.checkProxies()
-
-          this.networkFile.proxyAliases.should.be.empty
-        })
-      })
-
-      describe('when the app has one proxy registered', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-        })
-
-        it('adds that proxy', async function () {
-          await this.checker.checkProxies()
-
-          this.networkFile.proxyAliases.should.have.lengthOf(1)
-          this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-          this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-        })
-      })
-
-      describe('when the app has many proxies registered', function () {
-        beforeEach('registering new implementation in AppDirectory', async function () {
-          this.implProxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-          this.anotherImplProxy = await this.app.createProxy(AnotherImplV1, 'AnotherImpl', 'initialize', [1])
-        })
-
-        it('adds those proxies', async function () {
-          await this.checker.checkProxies()
-
-          this.networkFile.proxyAliases.should.have.lengthOf(2)
-          this.networkFile.proxy('Impl', 0).address.should.be.equal(this.implProxy.address)
-          this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-          this.networkFile.proxy('AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
-          this.networkFile.proxy('AnotherImpl', 0).version.should.be.equal('unknown')
-          this.networkFile.proxy('AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
-        })
-      })
-    })
-
-    describe('when the network file has two proxies', function () {
-      beforeEach('adding a proxy', async function () {
-        this.networkFile.setProxies('Impl', [
-          { implementation: this.impl.address, address: '0x1', version: '1.0' },
-          { implementation: this.impl.address, address: '0x2', version: '1.0' }
-        ])
-      })
-
-      describe('when the app does not have any proxy registered', function () {
-        it('removes those proxies', async function () {
-          await this.checker.checkProxies()
-
-          this.networkFile.proxyAliases.should.be.empty
-        })
-      })
-
-      describe('when the app has one proxy registered', function () {
-        beforeEach('creating a proxy', async function () {
-          this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
-        })
-
-        describe('when it matches one proxy address', function () {
-          describe('when it matches the alias and the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
-              ])
-            })
-
-            it('removes the unregistered proxy', async function () {
-              await this.checker.checkProxies()
-
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-            })
-          })
-
-          describe('when it matches the alias but not the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [
-                { implementation: this.impl.address, address: '0x1', version: '1.0' },
-                { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
-              ])
-            })
-
-            it('removes the unregistered proxy and updates the implementation of the registered one', async function () {
-              await this.checker.checkProxies()
-
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-            })
-          })
-
-          describe('when it matches the implementation address but not the alias', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
-            })
-
-            it('removes the unregistered proxy and updates the alias of the registered one', async function () {
-              await this.checker.checkProxies()
-
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-            })
-          })
-
-          describe('when it does not match the alias and the implementation address', function () {
-            beforeEach('changing network file', async function () {
-              this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
-              this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
-            })
-
-            it('removes the unregistered proxy and updates the alias and implementation of the registered one', async function () {
-              await this.checker.checkProxies()
-
-              this.networkFile.proxyAliases.should.have.lengthOf(1)
-              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
-              this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
-              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
-            })
-          })
-        })
-
-        describe('when it does not match any proxy address', function () {
-
-          it('removes the unregistered proxies and adds the registered onen', async function () {
+          it('adds that proxy', async function () {
             await this.checker.checkProxies()
 
             this.networkFile.proxyAliases.should.have.lengthOf(1)
@@ -535,7 +452,131 @@ contract('StatusFetcher', function([_, owner, anotherAddress]) {
             this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
           })
         })
+
+        describe('when the app has many proxies registered', function () {
+          beforeEach('registering new implementation in AppDirectory', async function () {
+            this.implProxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+            this.anotherImplProxy = await this.app.createProxy(AnotherImplV1, 'AnotherImpl', 'initialize', [1])
+          })
+
+          it('adds those proxies', async function () {
+            await this.checker.checkProxies()
+
+            this.networkFile.proxyAliases.should.have.lengthOf(2)
+            this.networkFile.proxy('Impl', 0).address.should.be.equal(this.implProxy.address)
+            this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
+            this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+            this.networkFile.proxy('AnotherImpl', 0).address.should.be.equal(this.anotherImplProxy.address)
+            this.networkFile.proxy('AnotherImpl', 0).version.should.be.equal('unknown')
+            this.networkFile.proxy('AnotherImpl', 0).implementation.should.be.equal(this.anotherImpl.address)
+          })
+        })
+      })
+
+      describe('when the network file has two proxies', function () {
+        beforeEach('adding a proxy', async function () {
+          this.networkFile.setProxies('Impl', [
+            { implementation: this.impl.address, address: '0x1', version: '1.0' },
+            { implementation: this.impl.address, address: '0x2', version: '1.0' }
+          ])
+        })
+
+        describe('when the app does not have any proxy registered', function () {
+          it('removes those proxies', async function () {
+            await this.checker.checkProxies()
+
+            this.networkFile.proxyAliases.should.be.empty
+          })
+        })
+
+        describe('when the app has one proxy registered', function () {
+          beforeEach('creating a proxy', async function () {
+            this.proxy = await this.app.createProxy(ImplV1, 'Impl', 'initialize', [42])
+          })
+
+          describe('when it matches one proxy address', function () {
+            describe('when it matches the alias and the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
+                  { implementation: this.impl.address, address: this.proxy.address, version: '1.0' },
+                ])
+              })
+
+              it('removes the unregistered proxy', async function () {
+                await this.checker.checkProxies()
+
+                this.networkFile.proxyAliases.should.have.lengthOf(1)
+                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
+                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              })
+            })
+
+            describe('when it matches the alias but not the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [
+                  { implementation: this.impl.address, address: '0x1', version: '1.0' },
+                  { implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' },
+                ])
+              })
+
+              it('removes the unregistered proxy and updates the implementation of the registered one', async function () {
+                await this.checker.checkProxies()
+
+                this.networkFile.proxyAliases.should.have.lengthOf(1)
+                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
+                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              })
+            })
+
+            describe('when it matches the implementation address but not the alias', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
+                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.impl.address, address: this.proxy.address, version: '1.0' }])
+              })
+
+              it('removes the unregistered proxy and updates the alias of the registered one', async function () {
+                await this.checker.checkProxies()
+
+                this.networkFile.proxyAliases.should.have.lengthOf(1)
+                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
+                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              })
+            })
+
+            describe('when it does not match the alias and the implementation address', function () {
+              beforeEach('changing network file', async function () {
+                this.networkFile.setProxies('Impl', [{ implementation: this.impl.address, address: '0x1', version: '1.0' }])
+                this.networkFile.setProxies('AnotherImpl', [{ implementation: this.anotherImpl.address, address: this.proxy.address, version: '1.0' }])
+              })
+
+              it('removes the unregistered proxy and updates the alias and implementation of the registered one', async function () {
+                await this.checker.checkProxies()
+
+                this.networkFile.proxyAliases.should.have.lengthOf(1)
+                this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
+                this.networkFile.proxy('Impl', 0).version.should.be.equal('1.0')
+                this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+              })
+            })
+          })
+
+          describe('when it does not match any proxy address', function () {
+
+            it('removes the unregistered proxies and adds the registered onen', async function () {
+              await this.checker.checkProxies()
+
+              this.networkFile.proxyAliases.should.have.lengthOf(1)
+              this.networkFile.proxy('Impl', 0).address.should.be.equal(this.proxy.address)
+              this.networkFile.proxy('Impl', 0).version.should.be.equal('unknown')
+              this.networkFile.proxy('Impl', 0).implementation.should.be.equal(this.impl.address)
+            })
+          })
+        })
       })
     })
-  })
+  };
 })


### PR DESCRIPTION
- Adds new abstraction PackageAtVersion, that represents a package with a specific version as default (we could move it to zos-lib).
- Replicates all tests for app and lib (where appropriate) for status fetcher and comparator.

I strongly suggest to review this PR with whitespace diff disabled
Fixes #314 